### PR TITLE
Fix build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
+          submodules: true
 
       - name: CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}}


### PR DESCRIPTION
- Don't recursively check out submodules in the build job.
- Adds a link to the Zulip to the README.
- Documents multiscale usage in the README.