### PR TITLE
Catch exceptions off the main thread

### DIFF
--- a/src/chunk.writer.cpp
+++ b/src/chunk.writer.cpp
@@ -166,8 +166,9 @@ ChunkWriter::write(const uint8_t* beg, const uint8_t* end)
     if (0 == bytes_in)
         return 0;
 
-    if (!current_file_.has_value())
-        open_chunk_file();
+    if (!current_file_.has_value()) {
+        CHECK(open_chunk_file());
+    }
 
     size_t bytes_out = 0;
     auto* cur = (uint8_t*)beg;

--- a/src/chunk.writer.hh
+++ b/src/chunk.writer.hh
@@ -39,7 +39,7 @@ struct ChunkWriter final
                 const std::string& base_directory);
     ~ChunkWriter();
 
-    [[nodiscard]] bool write_frame(const TiledFrame& frame);
+    [[nodiscard]] bool write_frame(const TiledFrame& frame) noexcept;
 
     const ImageShape& image_shape() const noexcept;
     const TileShape& tile_shape() const noexcept;
@@ -71,7 +71,7 @@ struct ChunkWriter final
 
     std::vector<uint8_t> buffer_;
 
-    void open_chunk_file();
+    [[nodiscard]] bool open_chunk_file();
     void close_current_file();
     size_t write(const uint8_t* beg, const uint8_t* end);
     void finalize_chunk();

--- a/src/frame.scaler.cpp
+++ b/src/frame.scaler.cpp
@@ -133,7 +133,7 @@ FrameScaler::FrameScaler(Zarr* zarr,
 }
 
 bool
-FrameScaler::push_frame(std::shared_ptr<TiledFrame> frame)
+FrameScaler::push_frame(std::shared_ptr<TiledFrame> frame) noexcept
 {
     std::unique_lock lock(mutex_);
     try {

--- a/src/frame.scaler.hh
+++ b/src/frame.scaler.hh
@@ -34,7 +34,7 @@ struct FrameScaler final
     FrameScaler(const FrameScaler&) = delete;
     ~FrameScaler() = default;
 
-    [[nodiscard]] bool push_frame(std::shared_ptr<TiledFrame> frame);
+    [[nodiscard]] bool push_frame(std::shared_ptr<TiledFrame> frame) noexcept;
 
   private:
     Zarr* zarr_; // non-owning

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -974,8 +974,9 @@ zarr::get_bytes_per_chunk(const ImageShape& image_shape,
 void
 zarr::write_string(const std::string& path, const std::string& str)
 {
-    if (auto p = fs::path(path); !fs::exists(p.parent_path()))
+    if (auto p = fs::path(path); !fs::exists(p.parent_path())) {
         fs::create_directories(p.parent_path());
+    }
 
     struct file f = { 0 };
     auto is_ok = file_create(&f, path.c_str(), path.size());

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -82,7 +82,7 @@ struct Zarr final : StorageInterface
     void reserve_image_shape(const ImageShape* shape) override;
 
     void push_frame_to_writers(const std::shared_ptr<TiledFrame> frame);
-    std::optional<JobT> pop_from_job_queue();
+    std::optional<JobT> pop_from_job_queue() noexcept;
 
   private:
     using ChunkingProps = StorageProperties::storage_properties_chunking_s;

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -84,6 +84,9 @@ struct Zarr final : StorageInterface
     void push_frame_to_writers(const std::shared_ptr<TiledFrame> frame);
     std::optional<JobT> pop_from_job_queue() noexcept;
 
+    /// @brief Set the error flag with a message.
+    void set_error(const std::string& msg) noexcept;
+
   private:
     using ChunkingProps = StorageProperties::storage_properties_chunking_s;
     using ChunkingMeta =
@@ -114,7 +117,10 @@ struct Zarr final : StorageInterface
     mutable std::mutex job_queue_mutex_;
     std::queue<JobT> job_queue_;
 
-    void set_chunking(const ChunkingProps& props, const ChunkingMeta& meta);
+    bool error_; // set to true if any thread encounters an error
+    std::string err_msg_;
+
+    void set_chunking_(const ChunkingProps& props, const ChunkingMeta& meta);
 
     void create_data_directory_() const;
     void write_zarray_json_() const;

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -179,7 +179,7 @@ void
 write_string(const std::string& path, const std::string& str);
 
 void
-worker_thread(ThreadContext* ctx);
+worker_thread(ThreadContext* ctx) noexcept;
 } // namespace acquire::sink::zarr
 
 #endif // H_ACQUIRE_STORAGE_ZARR_V0


### PR DESCRIPTION
- Makes `ChunkWriter::write_frame()` and `FrameScaler::push_frame()` both `noexcept`.
- Changes an in-thread call to `filesystem::create_directories` to use the non-throwing version.