### PR TITLE
Catch errors in push to job queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Removes `noexcept` specifier from various methods that don't need it and whose implementations may throw exceptions.
+
 ## [0.1.6](https://github.com/acquire-project/acquire-driver-zarr/compare/v0.1.5...v0.1.6) - 2023-11-28
 
 ### Fixed

--- a/src/writers/writer.cpp
+++ b/src/writers/writer.cpp
@@ -19,7 +19,7 @@ zarr::FileCreator::create_files(const fs::path& base_dir,
                                 int n_c,
                                 int n_y,
                                 int n_x,
-                                std::vector<file>& files) noexcept
+                                std::vector<file>& files)
 {
     base_dir_ = base_dir;
 
@@ -31,13 +31,8 @@ zarr::FileCreator::create_files(const fs::path& base_dir,
         return false;
     }
 
-    if (!create_c_dirs_(n_c)) {
-        return false;
-    }
-
-    if (!create_y_dirs_(n_c, n_y)) {
-        return false;
-    }
+    CHECK(create_c_dirs_(n_c));
+    CHECK(create_y_dirs_(n_c, n_y));
 
     const auto n_files = n_c * n_y * n_x;
 
@@ -95,7 +90,7 @@ zarr::FileCreator::create_files(const fs::path& base_dir,
 }
 
 bool
-zarr::FileCreator::create_c_dirs_(int n_c) noexcept
+zarr::FileCreator::create_c_dirs_(int n_c)
 {
     std::latch latch(n_c);
     std::atomic<bool> failure{ false };
@@ -136,7 +131,7 @@ zarr::FileCreator::create_c_dirs_(int n_c) noexcept
 }
 
 bool
-zarr::FileCreator::create_y_dirs_(int n_c, int n_y) noexcept
+zarr::FileCreator::create_y_dirs_(int n_c, int n_y)
 {
     std::latch latch(n_c * n_y);
     std::atomic<bool> failure{ false };
@@ -254,7 +249,7 @@ zarr::Writer::write(const VideoFrame* frame)
 }
 
 void
-zarr::Writer::finalize() noexcept
+zarr::Writer::finalize()
 {
     finalize_chunks_();
     if (bytes_to_flush_ > 0) {

--- a/src/writers/writer.hh
+++ b/src/writers/writer.hh
@@ -29,14 +29,14 @@ struct FileCreator
                                     int n_c,
                                     int n_y,
                                     int n_x,
-                                    std::vector<file>& files) noexcept;
+                                    std::vector<file>& files);
 
   private:
     fs::path base_dir_;
     std::shared_ptr<common::ThreadPool> thread_pool_;
 
-    bool create_c_dirs_(int n_c) noexcept;
-    bool create_y_dirs_(int n_c, int n_y) noexcept;
+    bool create_c_dirs_(int n_c);
+    bool create_y_dirs_(int n_c, int n_y);
 };
 
 struct Writer
@@ -59,7 +59,7 @@ struct Writer
     virtual ~Writer() noexcept = default;
 
     [[nodiscard]] bool write(const VideoFrame* frame);
-    void finalize() noexcept;
+    void finalize();
 
     uint32_t frames_written() const noexcept;
 
@@ -97,7 +97,7 @@ struct Writer
     void finalize_chunks_() noexcept;
     void compress_buffers_() noexcept;
     size_t write_frame_to_chunks_(const uint8_t* buf, size_t buf_size) noexcept;
-    virtual void flush_() noexcept = 0;
+    virtual void flush_() = 0;
 
     uint32_t tiles_per_frame_() const;
 

--- a/src/writers/zarrv2.writer.cpp
+++ b/src/writers/zarrv2.writer.cpp
@@ -34,7 +34,7 @@ zarr::ZarrV2Writer::ZarrV2Writer(
 }
 
 void
-zarr::ZarrV2Writer::flush_() noexcept
+zarr::ZarrV2Writer::flush_()
 {
     if (bytes_to_flush_ == 0) {
         return;

--- a/src/writers/zarrv2.writer.cpp
+++ b/src/writers/zarrv2.writer.cpp
@@ -44,10 +44,10 @@ zarr::ZarrV2Writer::flush_()
     const auto bytes_per_tile =
       tile_dims_.cols * tile_dims_.rows * bytes_per_px;
 
-    if (bytes_to_flush_ % bytes_per_tile != 0) {
-        LOGE("Expected bytes to flush to be a multiple of the "
-             "number of bytes per tile.");
-    }
+    EXPECT(bytes_per_tile != 0, "Expected bytes per tile to be non-zero.");
+    EXPECT(bytes_to_flush_ % bytes_per_tile != 0,
+           "Expected bytes to flush to be a multiple of the number of bytes "
+           "per tile.");
 
     // create chunk files if necessary
     if (files_.empty() &&

--- a/src/writers/zarrv2.writer.cpp
+++ b/src/writers/zarrv2.writer.cpp
@@ -45,7 +45,7 @@ zarr::ZarrV2Writer::flush_()
       tile_dims_.cols * tile_dims_.rows * bytes_per_px;
 
     EXPECT(bytes_per_tile != 0, "Expected bytes per tile to be non-zero.");
-    EXPECT(bytes_to_flush_ % bytes_per_tile != 0,
+    EXPECT(bytes_to_flush_ % bytes_per_tile == 0,
            "Expected bytes to flush to be a multiple of the number of bytes "
            "per tile.");
 

--- a/src/writers/zarrv2.writer.hh
+++ b/src/writers/zarrv2.writer.hh
@@ -40,7 +40,7 @@ struct ZarrV2Writer final : public Writer
     ~ZarrV2Writer() override = default;
 
   private:
-    void flush_() noexcept override;
+    void flush_() override;
 };
 } // namespace acquire::sink::zarr
 

--- a/src/writers/zarrv2.writer.hh
+++ b/src/writers/zarrv2.writer.hh
@@ -25,18 +25,18 @@ struct ZarrV2Writer final : public Writer
   public:
     ZarrV2Writer() = delete;
     ZarrV2Writer(const ImageDims& frame_dims,
-                const ImageDims& tile_dims,
-                uint32_t frames_per_chunk,
-                const std::string& data_root,
-                std::shared_ptr<common::ThreadPool> thread_pool);
+                 const ImageDims& tile_dims,
+                 uint32_t frames_per_chunk,
+                 const std::string& data_root,
+                 std::shared_ptr<common::ThreadPool> thread_pool);
 
     /// Constructor with Blosc compression params
     ZarrV2Writer(const ImageDims& frame_dims,
-                const ImageDims& tile_dims,
-                uint32_t frames_per_chunk,
-                const std::string& data_root,
-                std::shared_ptr<common::ThreadPool> thread_pool,
-                const BloscCompressionParams& compression_params);
+                 const ImageDims& tile_dims,
+                 uint32_t frames_per_chunk,
+                 const std::string& data_root,
+                 std::shared_ptr<common::ThreadPool> thread_pool,
+                 const BloscCompressionParams& compression_params);
     ~ZarrV2Writer() override = default;
 
   private:

--- a/src/writers/zarrv3.writer.cpp
+++ b/src/writers/zarrv3.writer.cpp
@@ -70,10 +70,10 @@ zarr::ZarrV3Writer::flush_()
     const auto bytes_per_tile =
       tile_dims_.cols * tile_dims_.rows * bytes_per_px;
 
-    if (bytes_to_flush_ % bytes_per_tile != 0) {
-        LOGE("Expected bytes to flush to be a multiple of the "
-             "number of bytes per tile.");
-    }
+    EXPECT(bytes_per_tile != 0, "Expected bytes per tile to be non-zero.");
+    EXPECT(bytes_to_flush_ % bytes_per_tile != 0,
+           "Expected bytes to flush to be a multiple of the number of bytes "
+           "per tile.");
 
     // create shard files if necessary
     if (files_.empty() && !file_creator_.create_files(

--- a/src/writers/zarrv3.writer.cpp
+++ b/src/writers/zarrv3.writer.cpp
@@ -60,7 +60,7 @@ zarr::ZarrV3Writer::shards_per_frame_() const
 }
 
 void
-zarr::ZarrV3Writer::flush_() noexcept
+zarr::ZarrV3Writer::flush_()
 {
     if (bytes_to_flush_ == 0) {
         return;

--- a/src/writers/zarrv3.writer.cpp
+++ b/src/writers/zarrv3.writer.cpp
@@ -71,7 +71,7 @@ zarr::ZarrV3Writer::flush_()
       tile_dims_.cols * tile_dims_.rows * bytes_per_px;
 
     EXPECT(bytes_per_tile != 0, "Expected bytes per tile to be non-zero.");
-    EXPECT(bytes_to_flush_ % bytes_per_tile != 0,
+    EXPECT(bytes_to_flush_ % bytes_per_tile == 0,
            "Expected bytes to flush to be a multiple of the number of bytes "
            "per tile.");
 

--- a/src/writers/zarrv3.writer.hh
+++ b/src/writers/zarrv3.writer.hh
@@ -49,7 +49,7 @@ struct ZarrV3Writer final : public Writer
     uint16_t chunks_per_shard_() const;
     uint16_t shards_per_frame_() const;
 
-    void flush_() noexcept override;
+    void flush_() override;
 };
 } // namespace acquire::sink::zarr
 


### PR DESCRIPTION
Closes #186.

- Removes `noexcept` specifier from several methods that don't need it.
- Checks that the divisor in a of couple modulus operations is nonzero.