### PR TITLE
Reset state on stop

### DIFF
--- a/src/common.hh
+++ b/src/common.hh
@@ -38,12 +38,6 @@ struct ImageDims
     uint32_t cols;
     uint32_t rows;
 
-    ImageDims(uint32_t cols, uint32_t rows) noexcept
-      : cols{ cols }
-      , rows{ rows }
-    {
-    }
-
     friend bool operator<=(const ImageDims& lhs, const ImageDims& rhs) noexcept
     {
         return (lhs.cols <= rhs.cols) && (lhs.rows <= rhs.rows);

--- a/src/common.hh
+++ b/src/common.hh
@@ -38,6 +38,12 @@ struct ImageDims
     uint32_t cols;
     uint32_t rows;
 
+    ImageDims(uint32_t cols, uint32_t rows) noexcept
+      : cols{ cols }
+      , rows{ rows }
+    {
+    }
+
     friend bool operator<=(const ImageDims& lhs, const ImageDims& rhs) noexcept
     {
         return (lhs.cols <= rhs.cols) && (lhs.rows <= rhs.rows);

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -127,12 +127,11 @@ DeviceState
 zarr_start(Storage* self_) noexcept
 {
     DeviceState state{ DeviceState_AwaitingConfiguration };
-
     try {
         CHECK(self_);
         auto* self = (zarr::Zarr*)self_;
         self->start();
-        state = DeviceState_Running;
+        state = self->state;
     } catch (const std::exception& exc) {
         LOGE("Exception: %s\n", exc.what());
     } catch (...) {
@@ -145,20 +144,18 @@ zarr_start(Storage* self_) noexcept
 DeviceState
 zarr_append(Storage* self_, const VideoFrame* frames, size_t* nbytes) noexcept
 {
-    DeviceState state;
+    DeviceState state{ DeviceState_AwaitingConfiguration };
     try {
         CHECK(self_);
         auto* self = (zarr::Zarr*)self_;
         *nbytes = self->append(frames, *nbytes);
-        state = DeviceState_Running;
+        state = self->state;
     } catch (const std::exception& exc) {
         *nbytes = 0;
         LOGE("Exception: %s\n", exc.what());
-        state = DeviceState_AwaitingConfiguration;
     } catch (...) {
         *nbytes = 0;
         LOGE("Exception: (unknown)");
-        state = DeviceState_AwaitingConfiguration;
     }
 
     return state;
@@ -172,8 +169,8 @@ zarr_stop(Storage* self_) noexcept
     try {
         CHECK(self_);
         auto* self = (zarr::Zarr*)self_;
-        CHECK(self->stop());
-        state = DeviceState_Armed;
+        CHECK(self->stop()); // state is set to DeviceState_Armed here
+        state = self->state;
     } catch (const std::exception& exc) {
         LOGE("Exception: %s\n", exc.what());
     } catch (...) {
@@ -320,6 +317,8 @@ average_two_frames(VideoFrame* dst, const VideoFrame* src)
 void
 zarr::Zarr::set(const StorageProperties* props)
 {
+    EXPECT(state != DeviceState_Running,
+           "Cannot set properties while running.");
     CHECK(props);
 
     StoragePropertyMetadata meta{};
@@ -424,6 +423,7 @@ zarr::Zarr::start()
       std::thread::hardware_concurrency(),
       [this](const std::string& err) { this->set_error(err); });
 
+    state = DeviceState_Running;
     error_ = false;
 }
 
@@ -464,6 +464,7 @@ zarr::Zarr::stop() noexcept
 size_t
 zarr::Zarr::append(const VideoFrame* frames, size_t nbytes)
 {
+    CHECK(DeviceState_Running == state);
     EXPECT(!error_, "%s", error_msg_.c_str());
 
     if (0 == nbytes) {
@@ -491,6 +492,9 @@ zarr::Zarr::append(const VideoFrame* frames, size_t nbytes)
 void
 zarr::Zarr::reserve_image_shape(const ImageShape* shape)
 {
+    EXPECT(state == DeviceState_Running,
+           "Can only reserve image shape while running.");
+
     // `shape` should be verified nonnull in storage_reserve_image_shape, but
     // let's check anyway
     CHECK(shape);

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -448,12 +448,13 @@ zarr::Zarr::stop() noexcept
             for (auto& writer : writers_) {
                 writer->finalize();
             }
-            writers_.clear();
 
             // call await_stop() before destroying to give jobs a chance to
             // finish
             thread_pool_->await_stop();
             thread_pool_ = nullptr;
+
+            reset_state_();
 
             is_ok = 1;
         } catch (const std::exception& exc) {
@@ -597,6 +598,24 @@ zarr::Zarr::set_chunking(const ChunkingProps& props, const ChunkingMeta& meta)
       props.planes, (uint32_t)meta.planes.low, (uint32_t)meta.planes.high);
 
     CHECK(planes_per_chunk_ > 0);
+}
+
+void
+zarr::Zarr::reset_state_()
+{
+    // reset state variables
+    writers_.clear();
+
+    // should be empty, but just in case
+    for (auto& [_, frame] : scaled_frames_) {
+        if (frame.has_value() && frame.value()) {
+            free(frame.value());
+        }
+    }
+    scaled_frames_.clear();
+
+    error_ = false;
+    error_msg_.clear();
 }
 
 void

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -353,10 +353,13 @@ zarr::Zarr::set(const StorageProperties* props)
 void
 zarr::Zarr::get(StorageProperties* props) const
 {
-    CHECK(storage_properties_set_filename(
-      props, dataset_root_.string().c_str(), dataset_root_.string().size()));
+    CHECK(storage_properties_set_filename(props,
+                                          dataset_root_.string().c_str(),
+                                          dataset_root_.string().size() + 1));
     CHECK(storage_properties_set_external_metadata(
-      props, external_metadata_json_.c_str(), external_metadata_json_.size()));
+      props,
+      external_metadata_json_.c_str(),
+      external_metadata_json_.size() + 1));
     props->pixel_scale_um = pixel_scale_um_;
 
     if (!image_tile_shapes_.empty()) {

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -352,11 +352,10 @@ zarr::Zarr::set(const StorageProperties* props)
 void
 zarr::Zarr::get(StorageProperties* props) const
 {
-    if (!dataset_root_.empty()) {
-        CHECK(
-          storage_properties_set_filename(props,
-                                          dataset_root_.string().c_str(),
-                                          dataset_root_.string().size() + 1));
+    if (const auto dataset_root = dataset_root_.string();
+        !dataset_root.empty()) {
+        CHECK(storage_properties_set_filename(
+          props, dataset_root.c_str(), dataset_root.size() + 1));
     }
     if (!external_metadata_json_.empty()) {
         CHECK(storage_properties_set_external_metadata(

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -352,14 +352,19 @@ zarr::Zarr::set(const StorageProperties* props)
 void
 zarr::Zarr::get(StorageProperties* props) const
 {
-    CHECK(storage_properties_set_filename(props,
+    if (!dataset_root_.empty()) {
+        CHECK(
+          storage_properties_set_filename(props,
                                           dataset_root_.string().c_str(),
                                           dataset_root_.string().size() + 1));
-    CHECK(storage_properties_set_external_metadata(
-      props,
-      external_metadata_json_.c_str(),
-      external_metadata_json_.size() + 1));
-    props->pixel_scale_um = pixel_scale_um_;
+    }
+    if (!external_metadata_json_.empty()) {
+        CHECK(storage_properties_set_external_metadata(
+          props,
+          external_metadata_json_.c_str(),
+          external_metadata_json_.size() + 1));
+        props->pixel_scale_um = pixel_scale_um_;
+    }
 
     if (!image_tile_shapes_.empty()) {
         props->chunk_dims_px.width = image_tile_shapes_.at(0).second.cols;

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -22,7 +22,7 @@ namespace fs = std::filesystem;
 
 namespace acquire::sink::zarr {
 
-struct Zarr: public Storage
+struct Zarr : public Storage
 {
   public:
     Zarr();
@@ -31,7 +31,7 @@ struct Zarr: public Storage
 
     /// Storage interface
     virtual void set(const StorageProperties* props);
-    void get(StorageProperties* props) const;
+    virtual void get(StorageProperties* props) const;
     virtual void get_meta(StoragePropertyMetadata* meta) const;
     void start();
     int stop() noexcept;

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -76,6 +76,7 @@ struct Zarr : public Storage
     /// Setup
     void set_chunking(const ChunkingProps& props, const ChunkingMeta& meta);
     virtual void allocate_writers_() = 0;
+    void reset_state_();
 
     /// Metadata
     void write_all_array_metadata_() const;

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -76,7 +76,6 @@ struct Zarr : public Storage
     /// Setup
     void set_chunking(const ChunkingProps& props, const ChunkingMeta& meta);
     virtual void allocate_writers_() = 0;
-    void reset_state_();
 
     /// Metadata
     void write_all_array_metadata_() const;

--- a/src/zarr.v3.cpp
+++ b/src/zarr.v3.cpp
@@ -88,6 +88,15 @@ zarr::ZarrV3::set(const StorageProperties* props)
 }
 
 void
+zarr::ZarrV3::get(StorageProperties* props) const
+{
+    Zarr::get(props);
+    props->shard_dims_chunks.width = shard_dims_.at(0).cols;
+    props->shard_dims_chunks.height = shard_dims_.at(0).rows;
+    props->shard_dims_chunks.planes = 1;
+}
+
+void
 zarr::ZarrV3::get_meta(StoragePropertyMetadata* meta) const
 {
     Zarr::get_meta(meta);

--- a/src/zarr.v3.cpp
+++ b/src/zarr.v3.cpp
@@ -37,11 +37,12 @@ zarr::ZarrV3::set_sharding(const ShardingProps& props, const ShardingMeta& meta)
     // tile shape (see reserve_image_shape) so we need to store the raw (i.e.,
     // per chunk) values.
     shard_dims_chunks_.clear();
-    shard_dims_chunks_.emplace_back(
-      std::clamp(
-        props.width, (uint32_t)meta.width.low, (uint32_t)meta.width.high),
-      std::clamp(
-        props.height, (uint32_t)meta.height.low, (uint32_t)meta.height.high));
+    shard_dims_chunks_.push_back({ std::clamp(props.width,
+                                              (uint32_t)meta.width.low,
+                                              (uint32_t)meta.width.high),
+                                   std::clamp(props.height,
+                                              (uint32_t)meta.height.low,
+                                              (uint32_t)meta.height.high) });
 }
 
 void

--- a/src/zarr.v3.hh
+++ b/src/zarr.v3.hh
@@ -22,7 +22,7 @@ struct ZarrV3 final : public Zarr
     using ShardingMeta =
       StoragePropertyMetadata::storage_property_metadata_sharding_s;
 
-    std::vector<ImageDims> shard_dims_;
+    std::vector<ImageDims> shard_dims_chunks_;
 
     /// Setup
     void set_sharding(const ShardingProps& props, const ShardingMeta& meta);

--- a/src/zarr.v3.hh
+++ b/src/zarr.v3.hh
@@ -13,6 +13,7 @@ struct ZarrV3 final : public Zarr
 
     /// Storage interface
     void set(const StorageProperties* props) override;
+    void get(StorageProperties* props) const override;
     void get_meta(StoragePropertyMetadata* meta) const override;
     void reserve_image_shape(const ImageShape* shape) override;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ else ()
     set(tests
             list-devices
             external-metadata-with-whitespace-ok
+            get
             get-meta
             restart-stopped-zarr-resets-threadpool
             unit-tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ else ()
             get
             get-meta
             restart-stopped-zarr-resets-threadpool
+            repeat-start
             unit-tests
             multiscale-with-trivial-tile-size
             no-set-chunking

--- a/tests/get.cpp
+++ b/tests/get.cpp
@@ -1,6 +1,5 @@
-/// @brief Check that Zarr devices implement the get_meta function.
-/// Also check that both chunking and multiscale are marked as supported and
-/// that the metadata for each is correct.
+/// @file get.cpp
+/// Check that Zarr devices correctly implement the `get` Storage API function.
 
 #include "platform.h"
 #include "logger.h"

--- a/tests/get.cpp
+++ b/tests/get.cpp
@@ -1,0 +1,146 @@
+/// @brief Check that Zarr devices implement the get_meta function.
+/// Also check that both chunking and multiscale are marked as supported and
+/// that the metadata for each is correct.
+
+#include "platform.h"
+#include "logger.h"
+#include "device/kit/driver.h"
+#include "device/hal/driver.h"
+#include "device/hal/storage.h"
+#include "device/props/storage.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#define containerof(P, T, F) ((T*)(((char*)(P)) - offsetof(T, F)))
+
+/// Helper for passing size static strings as function args.
+/// For a function: `f(char*,size_t)` use `f(SIZED("hello"))`.
+/// Expands to `f("hello",5)`.
+#define SIZED(str) str, strlen(str) + 1
+
+#define L aq_logger
+#define LOG(...) L(0, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define LOGE(...) L(1, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define EXPECT(e, ...)                                                         \
+    do {                                                                       \
+        if (!(e)) {                                                            \
+            LOGE(__VA_ARGS__);                                                 \
+            goto Error;                                                        \
+        }                                                                      \
+    } while (0)
+#define CHECK(e) EXPECT(e, "Expression evaluated as false:\n\t%s", #e)
+
+/// Check that a==b
+/// example: `ASSERT_EQ(int,"%d",42,meaning_of_life())`
+#define ASSERT_EQ(T, fmt, a, b)                                                \
+    do {                                                                       \
+        T a_ = (T)(a);                                                         \
+        T b_ = (T)(b);                                                         \
+        EXPECT(                                                                \
+          a_ == b_, "Expected %s==%s but " fmt "!=" fmt "\n", #a, #b, a_, b_); \
+    } while (0)
+
+void
+reporter(int is_error,
+         const char* file,
+         int line,
+         const char* function,
+         const char* msg)
+{
+    fprintf(is_error ? stderr : stdout,
+            "%s%s(%d) - %s: %s\n",
+            is_error ? "ERROR " : "",
+            file,
+            line,
+            function,
+            msg);
+}
+
+typedef struct Driver* (*init_func_t)(void (*reporter)(int is_error,
+                                                       const char* file,
+                                                       int line,
+                                                       const char* function,
+                                                       const char* msg));
+
+int
+main()
+{
+    logger_set_reporter(reporter);
+    lib lib{};
+    CHECK(lib_open_by_name(&lib, "acquire-driver-zarr"));
+    {
+        auto init = (init_func_t)lib_load(&lib, "acquire_driver_init_v0");
+        auto driver = init(reporter);
+        CHECK(driver);
+        const auto n = driver->device_count(driver);
+        for (uint32_t i = 0; i < n; ++i) {
+            DeviceIdentifier id{};
+            CHECK(driver->describe(driver, &id, i) == Device_Ok);
+
+            std::string name{ id.name };
+
+            if (id.kind == DeviceKind_Storage && name.starts_with("Zarr")) {
+                struct Device* device = nullptr;
+                struct Storage* storage = nullptr;
+
+                CHECK(Device_Ok == driver_open_device(driver, i, &device));
+                storage = containerof(device, struct Storage, device);
+
+                struct StorageProperties props = { 0 };
+                storage_properties_init(&props,
+                                        13,
+                                        SIZED(TEST ".zarr"),
+                                        SIZED(R"({"foo": "bar"})"),
+                                        { 1, 1 });
+                props.chunk_dims_px = {
+                    .width = 64,
+                    .height = 48,
+                    .planes = 6,
+                };
+                props.shard_dims_chunks = {
+                    .width = 3,
+                    .height = 2,
+                    .planes = 1,
+                };
+                props.enable_multiscale = true;
+
+                CHECK(Device_Ok == storage_set(storage, &props));
+                props = { 0 };
+
+                CHECK(Device_Ok == storage_get(storage, &props));
+
+                CHECK(strcmp(props.filename.str, TEST ".zarr") == 0);
+                CHECK(strcmp(props.external_metadata_json.str,
+                             R"({"foo": "bar"})") == 0);
+
+                CHECK(props.first_frame_id == 0); // this is ignored
+
+                CHECK(props.chunk_dims_px.width == 64);
+                CHECK(props.chunk_dims_px.height == 48);
+                // 32 is the minimum value for planes
+                CHECK(props.chunk_dims_px.planes == 32);
+
+                if (name.starts_with("ZarrV3")) {
+                    CHECK(props.shard_dims_chunks.width == 3);
+                    CHECK(props.shard_dims_chunks.height == 2);
+                    CHECK(props.shard_dims_chunks.planes == 1);
+                } else {
+                    CHECK(props.shard_dims_chunks.width == 0);
+                    CHECK(props.shard_dims_chunks.height == 0);
+                    CHECK(props.shard_dims_chunks.planes == 0);
+                }
+
+                CHECK(props.enable_multiscale == !name.starts_with("ZarrV3"));
+
+                CHECK(Device_Ok == driver_close_device(device));
+            }
+        }
+    }
+    lib_close(&lib);
+    return 0;
+Error:
+    lib_close(&lib);
+    return 1;
+}

--- a/tests/get.cpp
+++ b/tests/get.cpp
@@ -18,7 +18,7 @@
 /// Helper for passing size static strings as function args.
 /// For a function: `f(char*,size_t)` use `f(SIZED("hello"))`.
 /// Expands to `f("hello",5)`.
-#define SIZED(str) str, strlen(str) + 1
+#define SIZED(str) str, sizeof(str)
 
 #define L aq_logger
 #define LOG(...) L(0, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
@@ -92,7 +92,7 @@ main()
                 storage_properties_init(&props,
                                         13,
                                         SIZED(TEST ".zarr"),
-                                        SIZED(R"({"foo": "bar"})"),
+                                        SIZED(R"({"foo":"bar"})"),
                                         { 1, 1 });
                 props.chunk_dims_px = {
                     .width = 64,
@@ -113,7 +113,7 @@ main()
 
                 CHECK(strcmp(props.filename.str, TEST ".zarr") == 0);
                 CHECK(strcmp(props.external_metadata_json.str,
-                             R"({"foo": "bar"})") == 0);
+                             R"({"foo":"bar"})") == 0);
 
                 CHECK(props.first_frame_id == 0); // this is ignored
 

--- a/tests/repeat-start.cpp
+++ b/tests/repeat-start.cpp
@@ -113,8 +113,10 @@ validate(AcquireRuntime* runtime)
     AcquireProperties props = { 0 };
     OK(acquire_get_configuration(runtime, &props));
 
-    const fs::path test_path(TEST ".zarr");
-    CHECK(fs::is_directory(test_path));
+    const fs::path test_path(props.video[0].storage.settings.filename.str);
+    EXPECT(fs::is_directory(test_path),
+           "Expected %s to be a directory",
+           test_path.string().c_str());
 
     // check the zarr.json metadata file
     fs::path metadata_path = test_path / "zarr.json";

--- a/tests/repeat-start.cpp
+++ b/tests/repeat-start.cpp
@@ -1,0 +1,209 @@
+/// @file tests/repeat-start
+/// @brief Test that we can reuse a Zarr device after stopping it, with no error
+/// in acquisition.
+
+#include "logger.h"
+
+#include "acquire.h"
+#include "device/hal/device.manager.h"
+
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+
+#include "json.hpp"
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+#define containerof(P, T, F) ((T*)(((char*)(P)) - offsetof(T, F)))
+
+/// Helper for passing size static strings as function args.
+/// For a function: `f(char*,size_t)` use `f(SIZED("hello"))`.
+/// Expands to `f("hello",5)`.
+#define SIZED(str) str, sizeof(str) - 1
+
+#define L (aq_logger)
+#define LOG(...) L(0, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define ERR(...) L(1, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define EXPECT(e, ...)                                                         \
+    do {                                                                       \
+        if (!(e)) {                                                            \
+            char buf[1 << 8] = { 0 };                                          \
+            ERR(__VA_ARGS__);                                                  \
+            snprintf(buf, sizeof(buf) - 1, __VA_ARGS__);                       \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+#define CHECK(e) EXPECT(e, "Expression evaluated as false: %s", #e)
+#define DEVOK(e) CHECK(Device_Ok == (e))
+#define OK(e) CHECK(AcquireStatus_Ok == (e))
+
+/// example: `ASSERT_EQ(int,"%d",42,meaning_of_life())`
+#define ASSERT_EQ(T, fmt, a, b)                                                \
+    do {                                                                       \
+        T a_ = (T)(a);                                                         \
+        T b_ = (T)(b);                                                         \
+        EXPECT(a_ == b_, "Expected %s==%s but " fmt "!=" fmt, #a, #b, a_, b_); \
+    } while (0)
+
+void
+reporter(int is_error,
+         const char* file,
+         int line,
+         const char* function,
+         const char* msg)
+{
+    fprintf(is_error ? stderr : stdout,
+            "%s%s(%d) - %s: %s\n",
+            is_error ? "ERROR " : "",
+            file,
+            line,
+            function,
+            msg);
+}
+
+void
+configure(AcquireRuntime* runtime)
+{
+    struct AcquireProperties props = { 0 };
+    OK(acquire_get_configuration(runtime, &props));
+
+    auto dm = acquire_device_manager(runtime);
+    DEVOK(device_manager_select(dm,
+                                DeviceKind_Camera,
+                                SIZED("simulated.*random.*"),
+                                &props.video[0].camera.identifier));
+
+    props.video[0].camera.settings.binning = 1;
+    props.video[0].camera.settings.pixel_type = SampleType_u8;
+    props.video[0].camera.settings.shape = { .x = 64, .y = 48 };
+    props.video[0].camera.settings.exposure_time_us = 1e3;
+
+    DEVOK(device_manager_select(dm,
+                                DeviceKind_Storage,
+                                SIZED("ZarrV3") + 1,
+                                &props.video[0].storage.identifier));
+    CHECK(storage_properties_init(&props.video[0].storage.settings,
+                                  0,
+                                  SIZED(TEST ".zarr") + 1,
+                                  nullptr,
+                                  0,
+                                  { 1, 1 }));
+
+    CHECK(storage_properties_set_chunking_props(
+      &props.video[0].storage.settings, 32, 32, 32));
+    CHECK(storage_properties_set_sharding_props(
+      &props.video[0].storage.settings, 2, 1, 1));
+    props.video[0].max_frame_count = 10;
+
+    OK(acquire_configure(runtime, &props));
+}
+
+void
+acquire(AcquireRuntime* runtime)
+{
+    acquire_start(runtime);
+    acquire_stop(runtime);
+}
+
+void
+validate(AcquireRuntime* runtime)
+{
+    AcquireProperties props;
+    OK(acquire_get_configuration(runtime, &props));
+
+    const fs::path test_path(TEST ".zarr");
+    CHECK(fs::is_directory(test_path));
+
+    // check the zarr.json metadata file
+    fs::path metadata_path = test_path / "zarr.json";
+    CHECK(fs::is_regular_file(metadata_path));
+    std::ifstream f(metadata_path);
+    json metadata = json::parse(f);
+
+    CHECK(metadata["extensions"].empty());
+    CHECK("https://purl.org/zarr/spec/protocol/core/3.0" ==
+          metadata["metadata_encoding"]);
+    CHECK(".json" == metadata["metadata_key_suffix"]);
+    CHECK("https://purl.org/zarr/spec/protocol/core/3.0" ==
+          metadata["zarr_format"]);
+
+    // check the group metadata file
+    metadata_path = test_path / "meta" / "root.group.json";
+    CHECK(fs::is_regular_file(metadata_path));
+
+    f = std::ifstream(metadata_path);
+    metadata = json::parse(f);
+    CHECK("" == metadata["attributes"]["acquire"]);
+
+    // check the array metadata file
+    metadata_path = test_path / "meta" / "root" / "0.array.json";
+    CHECK(fs::is_regular_file(metadata_path));
+
+    f = std::ifstream(metadata_path);
+    metadata = json::parse(f);
+
+    const auto chunk_grid = metadata["chunk_grid"];
+    CHECK("/" == chunk_grid["separator"]);
+    CHECK("regular" == chunk_grid["type"]);
+
+    const auto chunk_shape = chunk_grid["chunk_shape"];
+    ASSERT_EQ(int, "%d", 10, chunk_shape[0]);
+    ASSERT_EQ(int, "%d", 1, chunk_shape[1]);
+    ASSERT_EQ(int, "%d", 32, chunk_shape[2]);
+    ASSERT_EQ(int, "%d", 32, chunk_shape[3]);
+
+    CHECK("C" == metadata["chunk_memory_layout"]);
+    CHECK("u1" == metadata["data_type"]);
+    CHECK(metadata["extensions"].empty());
+
+    const auto array_shape = metadata["shape"];
+    ASSERT_EQ(int, "%d", 10, array_shape[0]);
+    ASSERT_EQ(int, "%d", 1, array_shape[1]);
+    ASSERT_EQ(int, "%d", 48, array_shape[2]);
+    ASSERT_EQ(int, "%d", 64, array_shape[3]);
+
+    // sharding
+    const auto storage_transformers = metadata["storage_transformers"];
+    const auto configuration = storage_transformers[0]["configuration"];
+    const auto& cps = configuration["chunks_per_shard"];
+    ASSERT_EQ(int, "%d", 1, cps[0]);
+    ASSERT_EQ(int, "%d", 1, cps[1]);
+    ASSERT_EQ(int, "%d", 1, cps[2]);
+    ASSERT_EQ(int, "%d", 2, cps[3]);
+    const size_t chunks_per_shard = cps[0].get<size_t>() *
+                                    cps[1].get<size_t>() *
+                                    cps[2].get<size_t>() * cps[3].get<size_t>();
+
+    const auto index_size = 2 * chunks_per_shard * sizeof(uint64_t);
+
+    // check that the chunked data file is the expected size
+    const uint32_t bytes_per_chunk =
+      chunk_shape[0].get<uint32_t>() * chunk_shape[1].get<uint32_t>() *
+      chunk_shape[2].get<uint32_t>() * chunk_shape[3].get<uint32_t>();
+
+    fs::path path = test_path / "data" / "root" / "0" / "c0" / "0" / "0" / "0";
+
+    CHECK(fs::is_regular_file(path));
+
+    auto file_size = fs::file_size(path);
+
+    ASSERT_EQ(
+      int, "%d", chunks_per_shard* bytes_per_chunk + index_size, file_size);
+}
+
+int
+main()
+{
+    auto runtime = acquire_init(reporter);
+    configure(runtime);
+
+    for (auto i = 0; i < 2; ++i) {
+        acquire(runtime);
+        validate(runtime);
+    }
+
+    acquire_shutdown(runtime);
+    LOG("Done (OK)");
+}

--- a/tests/repeat-start.cpp
+++ b/tests/repeat-start.cpp
@@ -197,13 +197,23 @@ int
 main()
 {
     auto runtime = acquire_init(reporter);
-    configure(runtime);
 
-    for (auto i = 0; i < 2; ++i) {
-        acquire(runtime);
-        validate(runtime);
+    int retval = 1;
+    try {
+        configure(runtime);
+
+        for (auto i = 0; i < 2; ++i) {
+            acquire(runtime);
+            validate(runtime);
+        }
+        retval = 0;
+        LOG("Done (OK)");
+    } catch (const std::exception& e) {
+        ERR("Exception: %s", e.what());
+    } catch (...) {
+        ERR("Unknown exception");
     }
 
     acquire_shutdown(runtime);
-    LOG("Done (OK)");
+    return retval;
 }

--- a/tests/repeat-start.cpp
+++ b/tests/repeat-start.cpp
@@ -82,11 +82,11 @@ configure(AcquireRuntime* runtime)
 
     DEVOK(device_manager_select(dm,
                                 DeviceKind_Storage,
-                                SIZED("ZarrV3") + 1,
+                                SIZED("ZarrV3"),
                                 &props.video[0].storage.identifier));
     CHECK(storage_properties_init(&props.video[0].storage.settings,
                                   0,
-                                  SIZED(TEST ".zarr") + 1,
+                                  SIZED(TEST ".zarr"),
                                   nullptr,
                                   0,
                                   { 1, 1 }));
@@ -110,7 +110,7 @@ acquire(AcquireRuntime* runtime)
 void
 validate(AcquireRuntime* runtime)
 {
-    AcquireProperties props;
+    AcquireProperties props = { 0 };
     OK(acquire_get_configuration(runtime, &props));
 
     const fs::path test_path(TEST ".zarr");

--- a/tests/repeat-start.cpp
+++ b/tests/repeat-start.cpp
@@ -21,7 +21,7 @@ using json = nlohmann::json;
 /// Helper for passing size static strings as function args.
 /// For a function: `f(char*,size_t)` use `f(SIZED("hello"))`.
 /// Expands to `f("hello",5)`.
-#define SIZED(str) str, sizeof(str) - 1
+#define SIZED(str) str, sizeof(str)
 
 #define L (aq_logger)
 #define LOG(...) L(0, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)


### PR DESCRIPTION
- Fixes a couple of bugs in `Zarr::get()`
- Sets state in Zarr object from C API calls.
- Stores shard dims in units of chunks in Zarr V3 (previously px)
- Resets internal state on `Zarr::stop()`.