### PR TITLE
Clear `Zarr::acquisition_dimensions_` before setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.10](https://github.com/acquire-project/acquire-driver-zarr/compare/v0.1.10..v0.1.11) - 2024-04-22
+## [0.1.11](https://github.com/acquire-project/acquire-driver-zarr/compare/v0.1.10..v0.1.11) - 2024-04-22
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10](https://github.com/acquire-project/acquire-driver-zarr/compare/v0.1.10..v0.1.11) - 2024-04-22
+
+### Fixed
+
+- Acquisition dimensions can be reconfigured without causing a crash.
+
 ## [0.1.10](https://github.com/acquire-project/acquire-driver-zarr/compare/v0.1.9..v0.1.10) - 2024-03-29
 
 ### Added

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -460,9 +460,6 @@ zarr::Zarr::stop() noexcept
             // don't clear before all working threads have shut down
             writers_.clear();
 
-            // keep no record of
-            acquisition_dimensions_.clear();
-
             // should be empty, but just in case
             for (auto& [_, frame] : scaled_frames_) {
                 if (frame.has_value() && frame.value()) {
@@ -565,6 +562,8 @@ zarr::Zarr::set_dimensions_(const StorageProperties* props)
 {
     const auto dimension_count = props->acquisition_dimensions.size;
     EXPECT(dimension_count > 2, "Expected at least 3 dimensions.");
+
+    acquisition_dimensions_.clear();
 
     for (auto i = 0; i < dimension_count; ++i) {
         CHECK(props->acquisition_dimensions.data[i].name.str);

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -460,6 +460,9 @@ zarr::Zarr::stop() noexcept
             // don't clear before all working threads have shut down
             writers_.clear();
 
+            // keep no record of
+            acquisition_dimensions_.clear();
+
             // should be empty, but just in case
             for (auto& [_, frame] : scaled_frames_) {
                 if (frame.has_value() && frame.value()) {


### PR DESCRIPTION
In case we reuse the Zarr storage object, we want this to be empty before we start appending.