### PR TITLE
Accommodate, but do nothing with, S3 API changes.

### DIFF
--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -16,8 +16,8 @@ namespace {
 fs::path
 as_path(const StorageProperties& props)
 {
-    return { props.filename.str,
-             props.filename.str + props.filename.nbytes - 1 };
+    return { props.uri.str,
+             props.uri.str + props.uri.nbytes - 1 };
 }
 
 /// \brief Check that the JSON string is valid. (Valid can mean empty.)
@@ -47,8 +47,8 @@ validate_json(const char* str, size_t nbytes)
 void
 validate_props(const StorageProperties* props)
 {
-    EXPECT(props->filename.str, "Filename string is NULL.");
-    EXPECT(props->filename.nbytes, "Filename string is zero size.");
+    EXPECT(props->uri.str, "Filename string is NULL.");
+    EXPECT(props->uri.nbytes, "Filename string is zero size.");
 
     // check that JSON is correct (throw std::exception if not)
     validate_json(props->external_metadata_json.str,
@@ -194,6 +194,7 @@ zarr_set(Storage* self_, const StorageProperties* props) noexcept
     try {
         CHECK(self_);
         auto* self = (zarr::Zarr*)self_;
+        LOGE("Number of dimensions: %d", props->acquisition_dimensions.size);
         self->set(props);
     } catch (const std::exception& exc) {
         LOGE("Exception: %s\n", exc.what());
@@ -329,6 +330,7 @@ zarr::Zarr::set(const StorageProperties* props)
     EXPECT(state != DeviceState_Running,
            "Cannot set properties while running.");
     CHECK(props);
+    LOGE("Number of dimensions: %d", props->acquisition_dimensions.size);
 
     StoragePropertyMetadata meta{};
     get_meta(&meta);
@@ -560,6 +562,7 @@ zarr::Zarr::Zarr(BloscCompressionParams&& compression_params)
 void
 zarr::Zarr::set_dimensions_(const StorageProperties* props)
 {
+    LOGE("Zarr::set_dimensions_: %d", props->acquisition_dimensions.size);
     const auto dimension_count = props->acquisition_dimensions.size;
     EXPECT(dimension_count > 2, "Expected at least 3 dimensions.");
 

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -194,7 +194,6 @@ zarr_set(Storage* self_, const StorageProperties* props) noexcept
     try {
         CHECK(self_);
         auto* self = (zarr::Zarr*)self_;
-        LOGE("Number of dimensions: %d", props->acquisition_dimensions.size);
         self->set(props);
     } catch (const std::exception& exc) {
         LOGE("Exception: %s\n", exc.what());
@@ -330,7 +329,6 @@ zarr::Zarr::set(const StorageProperties* props)
     EXPECT(state != DeviceState_Running,
            "Cannot set properties while running.");
     CHECK(props);
-    LOGE("Number of dimensions: %d", props->acquisition_dimensions.size);
 
     StoragePropertyMetadata meta{};
     get_meta(&meta);

--- a/tests/get.cpp
+++ b/tests/get.cpp
@@ -92,9 +92,9 @@ main()
                 // unconfigured behavior
                 CHECK(storage_get(storage, &props) == Device_Ok);
 
-                CHECK(props.filename.str);
-                CHECK(strcmp(props.filename.str, "") == 0);
-                CHECK(props.filename.nbytes == 1);
+                CHECK(props.uri.str);
+                CHECK(strcmp(props.uri.str, "") == 0);
+                CHECK(props.uri.nbytes == 1);
 
                 CHECK(props.external_metadata_json.str);
                 CHECK(strcmp(props.external_metadata_json.str, "") == 0);
@@ -132,7 +132,7 @@ main()
                 CHECK(Device_Ok == storage_set(storage, &props));
                 CHECK(Device_Ok == storage_get(storage, &props));
 
-                CHECK(strcmp(props.filename.str, TEST ".zarr") == 0);
+                CHECK(strcmp(props.uri.str, TEST ".zarr") == 0);
                 CHECK(strcmp(props.external_metadata_json.str,
                              R"({"foo":"bar"})") == 0);
 

--- a/tests/repeat-start.cpp
+++ b/tests/repeat-start.cpp
@@ -141,7 +141,7 @@ validate(AcquireRuntime* runtime)
     AcquireProperties props = { 0 };
     OK(acquire_get_configuration(runtime, &props));
 
-    const fs::path test_path(props.video[0].storage.settings.filename.str);
+    const fs::path test_path(props.video[0].storage.settings.uri.str);
     EXPECT(fs::is_directory(test_path),
            "Expected %s to be a directory",
            test_path.string().c_str());


### PR DESCRIPTION
Necessary to push a new [bugfix](https://github.com/acquire-project/acquire-python/pull/187) release to acquire-python.

As an alternative, we can point the acquire-common submodule of acquire-python to a branch off of https://github.com/acquire-project/acquire-common/commit/4444f5c95f699e22b47e9a6e321359016faa03e6 with the fixes [here](https://github.com/acquire-project/acquire-common/pull/43).