### PR TITLE
Enforce CXX standard in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ include(cmake/simd.cmake)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/src/writers/blosc.compressor.hh
+++ b/src/writers/blosc.compressor.hh
@@ -1,10 +1,6 @@
 #ifndef H_ACQUIRE_ZARR_BLOSC_COMPRESSOR_V0
 #define H_ACQUIRE_ZARR_BLOSC_COMPRESSOR_V0
 
-#ifndef __cplusplus
-#error "This header requires C++20"
-#endif
-
 #include "blosc.h"
 #include "json.hpp"
 

--- a/src/writers/writer.hh
+++ b/src/writers/writer.hh
@@ -1,10 +1,6 @@
 #ifndef H_ACQUIRE_ZARR_WRITER_V0
 #define H_ACQUIRE_ZARR_WRITER_V0
 
-#ifndef __cplusplus
-#error "This header requires C++20"
-#endif
-
 #include "platform.h"
 #include "device/props/components.h"
 

--- a/src/writers/zarrv2.writer.hh
+++ b/src/writers/zarrv2.writer.hh
@@ -1,10 +1,6 @@
 #ifndef H_ACQUIRE_ZARR_V2_WRITER_V0
 #define H_ACQUIRE_ZARR_V2_WRITER_V0
 
-#ifndef __cplusplus
-#error "This header requires C++20"
-#endif
-
 #include "writer.hh"
 
 #include "platform.h"

--- a/src/writers/zarrv3.writer.hh
+++ b/src/writers/zarrv3.writer.hh
@@ -1,10 +1,6 @@
 #ifndef H_ACQUIRE_ZARR_V3_WRITER_V0
 #define H_ACQUIRE_ZARR_V3_WRITER_V0
 
-#ifndef __cplusplus
-#error "This header requires C++20"
-#endif
-
 #include "writer.hh"
 
 #include "platform.h"

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -1,10 +1,6 @@
 #ifndef H_ACQUIRE_STORAGE_ZARR_V0
 #define H_ACQUIRE_STORAGE_ZARR_V0
 
-#ifndef __cplusplus
-#error "This header requires C++20"
-#endif
-
 #include "device/kit/storage.h"
 
 #include "common.hh"


### PR DESCRIPTION
**Summary**

This PR enables `CMAKE_CXX_STANDARD_REQUIRED` to enforce C++20. CMake will raise
an error if a compatible compiler is not found.

(see inline comments for more.)