### PR TITLE
Use vcpkg in build and release jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,13 @@ jobs:
       matrix:
         build_type: [ Debug, Release ]
         platform: [ "windows-latest", "ubuntu-latest", "macos-latest" ]
+        include:
+          - platform: "windows-latest"
+            vcpkg_triplet: "x64-windows-static"
+          - platform: "ubuntu-latest"
+            vcpkg_triplet: "x64-linux"
+          - platform: "macos-latest"
+            vcpkg_triplet: "arm64-osx"
 
     runs-on: ${{ matrix.platform }}
 
@@ -26,8 +33,19 @@ jobs:
         with:
           submodules: true
 
+      - name: Install vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          cd vcpkg && ./bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
+          echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH
+          ./vcpkg integrate install
+        shell: bash
+
       - name: CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+        run: |
+          cmake --preset=default -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}}
+          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,13 @@ jobs:
     strategy:
       matrix:
         platform: [ "windows-latest", "ubuntu-latest", "macos-latest" ]
+        include:
+          - platform: "windows-latest"
+            vcpkg_triplet: "x64-windows-static"
+          - platform: "ubuntu-latest"
+            vcpkg_triplet: "x64-linux"
+          - platform: "macos-latest"
+            vcpkg_triplet: "arm64-osx"
     runs-on: ${{ matrix.platform }}
 
     permissions:
@@ -29,8 +36,18 @@ jobs:
         with:
           submodules: true
 
+      - name: Install vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          cd vcpkg && ./bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
+          echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH
+          ./vcpkg integrate install
+        shell: bash
+
       - name: Build
         run: |
+          cmake --preset=default -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}}
           cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
           cmake --build ${{github.workspace}}/build --config Release
 

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -41,15 +41,6 @@ jobs:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install Cmake 3.23
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install cmake-data
-          wget -O cmake.sh https://cmake.org/files/v3.23/cmake-3.23.2-linux-x86_64.sh
-          sudo bash cmake.sh --skip-license --exclude-subdir --prefix=/usr/local
-        shell: bash
-
       - name: Install vcpkg
         run: |
           git clone https://github.com/microsoft/vcpkg.git


### PR DESCRIPTION
- Install and configure vcpkg in both build and release jobs
- Remove CMake 3.23 requirement for ubuntu-latest tests