### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   push:
     branches: [ "main" ]
+  pull_request: # TODO (aliddell): revert
+    branches:
+      - main
 
 jobs:
   build:
@@ -16,7 +19,7 @@ jobs:
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
           - platform: "macos-latest"
-            vcpkg_triplet: "arm64-osx"
+            vcpkg_triplet: "x64-osx"
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
           - platform: "macos-latest"
-            vcpkg_triplet: "arm64-osx"
+            vcpkg_triplet: "x64-osx"
     runs-on: ${{ matrix.platform }}
 
     permissions:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,6 +23,7 @@ if (${WITH_EXAMPLES})
                 acquire-core-logger
                 acquire-core-platform
                 acquire-video-runtime
+                nlohmann_json::nlohmann_json
         )
     endforeach ()
 

--- a/examples/no-striping.cpp
+++ b/examples/no-striping.cpp
@@ -12,7 +12,7 @@
 #include <fstream>
 #include <stdexcept>
 
-#include "tests/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace fs = std::filesystem;
 using json = nlohmann::json;

--- a/src/zarr.cpp
+++ b/src/zarr.cpp
@@ -141,8 +141,9 @@ scale_image(const VideoFrame* src)
     const auto height = src->shape.dims.height;
     const auto h_pad = height + (height % downscale);
 
-    auto* dst = (VideoFrame*)malloc(sizeof(VideoFrame) +
-                                    w_pad * h_pad * factor * sizeof(T));
+    const size_t bytes_of_frame = common::align_up(
+      sizeof(VideoFrame) + w_pad * h_pad * factor * bytes_of_type, 8);
+    auto* dst = (VideoFrame*)malloc(bytes_of_frame);
     memcpy(dst, src, sizeof(VideoFrame));
 
     dst->shape.dims.width = w_pad / downscale;
@@ -152,12 +153,11 @@ scale_image(const VideoFrame* src)
     dst->shape.strides.planes =
       dst->shape.strides.height * dst->shape.dims.height;
 
-    dst->bytes_of_frame =
-      common::align_up(bytes_of_image(&dst->shape) + sizeof(*dst), 8);
+    dst->bytes_of_frame = bytes_of_frame;
 
     const auto* src_img = (T*)src->data;
     auto* dst_img = (T*)dst->data;
-    memset(dst_img, 0, dst->bytes_of_frame - sizeof(*dst));
+    memset(dst_img, 0, bytes_of_image(&dst->shape));
 
     size_t dst_idx = 0;
     for (auto row = 0; row < height; row += downscale) {


### PR DESCRIPTION
- Use the x64-osx triplet for build and release jobs on Mac (see error [here](https://github.com/acquire-project/acquire-driver-zarr/actions/runs/9765062597/job/26958778874))
- Link nlohmann_json::nlohmann_json in examples
- Fix array size bug in downsampling