### PR TITLE
Remove Automerge job

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -61,29 +61,3 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         run: ctest -C ${{env.BUILD_TYPE}} -L acquire-driver-zarr --output-on-failure
-
-  merge:
-    name: Automerge
-    runs-on: "ubuntu-latest"
-    needs: test
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: Checkout PR
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.PAT }}
-
-      # Don't auto-merge major version updates
-      - name: Merge PR
-        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
Since we don't have as many submodules as we used to, and we don't update it as frequently as we used to, handling Dependabot PRs manually is not as much of a chore as it used to be. Consequently, we don't need Automerge anymore, and since we don't need the secret, we can change our trigger back to `pull_request`.

- Remove automerge job
- Change test trigger from `pull_request_target` back to `pull_request`
