### PR TITLE
Add minio using CMake FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(cmake/ide.cmake)
 include(cmake/install-prefix.cmake)
 include(cmake/wsl.cmake)
 include(cmake/simd.cmake)
+include(cmake/minio.cmake)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)

--- a/cmake/minio.cmake
+++ b/cmake/minio.cmake
@@ -1,0 +1,10 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  minio
+  GIT_REPOSITORY https://github.com/minio/minio-cpp.git
+  GIT_TAG origin/main # TODO: replace with a specific commit or tag before merging
+  GIT_SHALLOW true
+)
+
+FetchContent_MakeAvailable(minio)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${tgt} PRIVATE
         acquire-device-properties
         blosc_static
         nlohmann_json::nlohmann_json
+        miniocpp::miniocpp
 )
 set_target_properties(${tgt} PROPERTIES
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,11 @@
     {
         "name": "nlohmann-json",
         "version>=": "3.11.3"
-    }
+    },
+    { "name": "curlpp" },
+    { "name": "inih", "features": ["cpp"] },
+    { "name": "openssl" },
+    { "name": "pugixml" },
+    { "name": "zlib", "platform": "windows" }
   ]
 }


### PR DESCRIPTION
**Summary:**

I’m not sure if we considered using FetchContent to import minio from the main
branch. Here’s an example of how it would work. I haven’t tested it, but it
seems to build fine locally. Let me know if this works for you. Otherwise, we
can close it and merge #275 instead.