### PR TITLE
Add an append method that takes frame data, size, and shape

### DIFF
--- a/src/writers/writer.hh
+++ b/src/writers/writer.hh
@@ -44,7 +44,7 @@ struct Writer
 
     virtual ~Writer() noexcept = default;
 
-    [[nodiscard]] bool write(const VideoFrame* frame);
+    [[nodiscard]] size_t write(const uint8_t* data, size_t bytes_of_frame);
     void finalize();
 
     const WriterConfig& config() const noexcept;
@@ -72,7 +72,6 @@ struct Writer
     bool is_finalizing_;
 
     void make_buffers_() noexcept;
-    void validate_frame_(const VideoFrame* frame);
     size_t write_frame_to_chunks_(const uint8_t* buf, size_t buf_size);
     bool should_flush_() const;
     void compress_buffers_() noexcept;

--- a/src/writers/zarrv2.writer.cpp
+++ b/src/writers/zarrv2.writer.cpp
@@ -86,9 +86,46 @@ extern "C"
 {
     acquire_export int unit_test__zarrv2_writer__write_even()
     {
-        const fs::path base_dir = fs::temp_directory_path() / "acquire";
-        struct VideoFrame* frame = nullptr;
         int retval = 0;
+        const fs::path base_dir = fs::temp_directory_path() / "acquire";
+
+        const unsigned int array_width = 64, array_height = 48,
+                           array_planes = 6, array_channels = 8,
+                           array_timepoints = 10;
+        const unsigned int n_frames =
+          array_planes * array_channels * array_timepoints;
+
+        const unsigned int chunk_width = 16, chunk_height = 16,
+                           chunk_planes = 2, chunk_channels = 4,
+                           chunk_timepoints = 5;
+
+        const unsigned int chunks_in_x =
+          (array_width + chunk_width - 1) / chunk_width; // 4 chunks
+        const unsigned int chunks_in_y =
+          (array_height + chunk_height - 1) / chunk_height; // 3 chunks
+
+        const unsigned int chunks_in_z =
+          (array_planes + chunk_planes - 1) / chunk_planes; // 3 chunks
+        const unsigned int chunks_in_c =
+          (array_channels + chunk_channels - 1) / chunk_channels; // 2 chunks
+        const unsigned int chunks_in_t =
+          (array_timepoints + chunk_timepoints - 1) /
+          chunk_timepoints; // 2 chunks
+
+        const ImageShape shape
+          {
+              .dims = {
+                .width = array_width,
+                .height = array_height,
+              },
+              .strides = {
+                .width = 1,
+                .height = array_width,
+                .planes = array_width * array_height,
+              },
+              .type = SampleType_u16,
+          };
+        const unsigned int nbytes_px = bytes_of_type(shape.type);
 
         try {
             auto thread_pool = std::make_shared<common::ThreadPool>(
@@ -96,26 +133,16 @@ extern "C"
               [](const std::string& err) { LOGE("Error: %s\n", err.c_str()); });
 
             std::vector<zarr::Dimension> dims;
-            dims.emplace_back("x", DimensionType_Space, 64, 16, 0); // 4 chunks
-            dims.emplace_back("y", DimensionType_Space, 48, 16, 0); // 3 chunks
-            dims.emplace_back("z", DimensionType_Space, 6, 2, 0);   // 3 chunks
-            dims.emplace_back("c", DimensionType_Channel, 8, 4, 0); // 2 chunks
             dims.emplace_back(
-              "t", DimensionType_Time, 0, 5, 0); // 5 timepoints / chunk
-
-            ImageShape shape {
-                .dims = {
-                  .width = 64,
-                  .height = 48,
-                },
-                .strides = {
-                  .channels = 1,
-                  .width = 1,
-                  .height = 64,
-                  .planes = 64 * 48
-                },
-                .type = SampleType_u16,
-            };
+              "x", DimensionType_Space, array_width, chunk_width, 0);
+            dims.emplace_back(
+              "y", DimensionType_Space, array_height, chunk_height, 0);
+            dims.emplace_back(
+              "z", DimensionType_Space, array_planes, chunk_planes, 0);
+            dims.emplace_back(
+              "c", DimensionType_Channel, array_channels, chunk_channels, 0);
+            dims.emplace_back(
+              "t", DimensionType_Time, array_timepoints, chunk_timepoints, 0);
 
             zarr::WriterConfig config = {
                 .image_shape = shape,
@@ -126,64 +153,58 @@ extern "C"
 
             zarr::ZarrV2Writer writer(config, thread_pool);
 
-            const size_t frame_size = 64 * 48 * 2;
+            const size_t frame_size = array_width * array_height * nbytes_px;
+            std::vector<uint8_t> data(frame_size, 0);
 
-            frame = (VideoFrame*)malloc(sizeof(VideoFrame) + frame_size);
-            frame->bytes_of_frame =
-              common::align_up(sizeof(VideoFrame) + frame_size, 8);
-            frame->shape = shape;
-            memset(frame->data, 0, frame_size);
-
-            for (auto i = 0; i < 6 * 8 * 5 * 2; ++i) { // 2 time points
-                frame->frame_id = i;
-                CHECK(writer.write(frame));
+            for (auto i = 0; i < n_frames; ++i) { // 2 time points
+                CHECK(writer.write(data.data(), frame_size));
             }
             writer.finalize();
 
-            const auto expected_file_size = 16 * // x
-                                            16 * // y
-                                            2 *  // z
-                                            4 *  // c
-                                            5 *  // t
-                                            2;   // bytes per pixel
+            const auto expected_file_size = chunk_width * chunk_height *
+                                            chunk_planes * chunk_channels *
+                                            chunk_timepoints * nbytes_px;
 
             CHECK(fs::is_directory(base_dir));
-            for (auto t = 0; t < 2; ++t) {
+            for (auto t = 0; t < chunks_in_t; ++t) {
                 const auto t_dir = base_dir / std::to_string(t);
                 CHECK(fs::is_directory(t_dir));
 
-                for (auto c = 0; c < 2; ++c) {
+                for (auto c = 0; c < chunks_in_c; ++c) {
                     const auto c_dir = t_dir / std::to_string(c);
                     CHECK(fs::is_directory(c_dir));
 
-                    for (auto z = 0; z < 3; ++z) {
+                    for (auto z = 0; z < chunks_in_z; ++z) {
                         const auto z_dir = c_dir / std::to_string(z);
                         CHECK(fs::is_directory(z_dir));
 
-                        for (auto y = 0; y < 3; ++y) {
+                        for (auto y = 0; y < chunks_in_y; ++y) {
                             const auto y_dir = z_dir / std::to_string(y);
                             CHECK(fs::is_directory(y_dir));
 
-                            for (auto x = 0; x < 4; ++x) {
+                            for (auto x = 0; x < chunks_in_x; ++x) {
                                 const auto x_file = y_dir / std::to_string(x);
                                 CHECK(fs::is_regular_file(x_file));
                                 const auto file_size = fs::file_size(x_file);
                                 CHECK(file_size == expected_file_size);
                             }
 
-                            CHECK(!fs::is_regular_file(y_dir / "4"));
+                            CHECK(!fs::is_regular_file(
+                              y_dir / std::to_string(chunks_in_x)));
                         }
 
-                        CHECK(!fs::is_directory(z_dir / "3"));
+                        CHECK(!fs::is_directory(z_dir /
+                                                std::to_string(chunks_in_y)));
                     }
 
-                    CHECK(!fs::is_directory(c_dir / "3"));
+                    CHECK(
+                      !fs::is_directory(c_dir / std::to_string(chunks_in_z)));
                 }
 
-                CHECK(!fs::is_directory(t_dir / "2"));
+                CHECK(!fs::is_directory(t_dir / std::to_string(chunks_in_c)));
             }
 
-            CHECK(!fs::is_directory(base_dir / "2"));
+            CHECK(!fs::is_directory(base_dir / std::to_string(chunks_in_t)));
 
             retval = 1;
         } catch (const std::exception& exc) {
@@ -195,43 +216,58 @@ extern "C"
         // cleanup
         if (fs::exists(base_dir)) {
             fs::remove_all(base_dir);
-        }
-        if (frame) {
-            free(frame);
         }
         return retval;
     }
 
     acquire_export int unit_test__zarrv2_writer__write_ragged_append_dim()
     {
-        const fs::path base_dir = fs::temp_directory_path() / "acquire";
-        struct VideoFrame* frame = nullptr;
         int retval = 0;
+        const fs::path base_dir = fs::temp_directory_path() / "acquire";
+
+        const unsigned int array_width = 64, array_height = 48,
+                           array_planes = 5;
+        const unsigned int n_frames =
+          array_planes;
+
+        const unsigned int chunk_width = 16, chunk_height = 16,
+                           chunk_planes = 2;
+
+        const unsigned int chunks_in_x =
+          (array_width + chunk_width - 1) / chunk_width; // 4 chunks
+        const unsigned int chunks_in_y =
+          (array_height + chunk_height - 1) / chunk_height; // 3 chunks
+
+        const unsigned int chunks_in_z =
+          (array_planes + chunk_planes - 1) / chunk_planes; // 3 chunks, ragged
+
+        const ImageShape shape
+          {
+              .dims = {
+                .width = array_width,
+                .height = array_height,
+              },
+              .strides = {
+                .width = 1,
+                .height = array_width,
+                .planes = array_width * array_height,
+              },
+              .type = SampleType_u8,
+          };
+        const unsigned int nbytes_px = bytes_of_type(shape.type);
 
         try {
             auto thread_pool = std::make_shared<common::ThreadPool>(
               std::thread::hardware_concurrency(),
               [](const std::string& err) { LOGE("Error: %s", err.c_str()); });
 
-            ImageShape shape {
-                .dims = {
-                  .width = 64,
-                  .height = 48,
-                },
-                .strides = {
-                  .channels = 1,
-                  .width = 1,
-                  .height = 64,
-                  .planes = 64 * 48
-                },
-                .type = SampleType_u8,
-            };
-
             std::vector<zarr::Dimension> dims;
-            dims.emplace_back("x", DimensionType_Space, 64, 16, 0); // 4 chunks
-            dims.emplace_back("y", DimensionType_Space, 48, 16, 0); // 3 chunks
             dims.emplace_back(
-              "z", DimensionType_Space, 5, 2, 0); // 3 chunks, ragged
+              "x", DimensionType_Space, array_width, chunk_width, 0);
+            dims.emplace_back(
+              "y", DimensionType_Space, array_height, chunk_height, 0);
+            dims.emplace_back(
+              "z", DimensionType_Space, array_planes, chunk_planes, 0);
 
             zarr::WriterConfig config = {
                 .image_shape = shape,
@@ -242,45 +278,41 @@ extern "C"
 
             zarr::ZarrV2Writer writer(config, thread_pool);
 
-            frame = (VideoFrame*)malloc(sizeof(VideoFrame) + 64 * 48);
-            frame->bytes_of_frame =
-              common::align_up(sizeof(VideoFrame) + 64 * 48, 8);
-            frame->shape = shape;
-            memset(frame->data, 0, 64 * 48);
+            const size_t frame_size = array_width * array_height * nbytes_px;
+            std::vector<uint8_t> data(frame_size, 0);
 
-            for (auto i = 0; i < 5; ++i) { // z dimension is ragged
-                frame->frame_id = i;
-                CHECK(writer.write(frame));
+            for (auto i = 0; i < n_frames; ++i) {
+                CHECK(writer.write(data.data(), frame_size) == frame_size);
             }
             writer.finalize();
 
-            const auto expected_file_size = 16 * // x
-                                            16 * // y
-                                            2;   // z
+            const auto expected_file_size =
+              chunk_width * chunk_height * chunk_planes;
 
             CHECK(fs::is_directory(base_dir));
-            for (auto z = 0; z < 3; ++z) {
+            for (auto z = 0; z < chunks_in_z; ++z) {
                 const auto z_dir = base_dir / std::to_string(z);
                 CHECK(fs::is_directory(z_dir));
 
-                for (auto y = 0; y < 3; ++y) {
+                for (auto y = 0; y < chunks_in_y; ++y) {
                     const auto y_dir = z_dir / std::to_string(y);
                     CHECK(fs::is_directory(y_dir));
 
-                    for (auto x = 0; x < 4; ++x) {
+                    for (auto x = 0; x < chunks_in_x; ++x) {
                         const auto x_file = y_dir / std::to_string(x);
                         CHECK(fs::is_regular_file(x_file));
                         const auto file_size = fs::file_size(x_file);
                         CHECK(file_size == expected_file_size);
                     }
 
-                    CHECK(!fs::is_regular_file(y_dir / "4"));
+                    CHECK(!fs::is_regular_file(y_dir /
+                                               std::to_string(chunks_in_x)));
                 }
 
-                CHECK(!fs::is_directory(z_dir / "3"));
+                CHECK(!fs::is_directory(z_dir / std::to_string(chunks_in_y)));
             }
 
-            CHECK(!fs::is_directory(base_dir / "3"));
+            CHECK(!fs::is_directory(base_dir / std::to_string(chunks_in_z)));
 
             retval = 1;
         } catch (const std::exception& exc) {
@@ -293,44 +325,61 @@ extern "C"
         if (fs::exists(base_dir)) {
             fs::remove_all(base_dir);
         }
-        if (frame) {
-            free(frame);
-        }
         return retval;
     }
 
     acquire_export int unit_test__zarrv2_writer__write_ragged_internal_dim()
     {
-        const fs::path base_dir = fs::temp_directory_path() / "acquire";
-        struct VideoFrame* frame = nullptr;
         int retval = 0;
+        const fs::path base_dir = fs::temp_directory_path() / "acquire";
+
+        const unsigned int array_width = 64, array_height = 48,
+                           array_planes = 5, array_timepoints = 5;
+        const unsigned int n_frames = array_planes * array_timepoints;
+
+        const unsigned int chunk_width = 16, chunk_height = 16,
+                           chunk_planes = 2, chunk_timepoints = 5;
+
+        const unsigned int chunks_in_x =
+          (array_width + chunk_width - 1) / chunk_width; // 4 chunks
+        const unsigned int chunks_in_y =
+          (array_height + chunk_height - 1) / chunk_height; // 3 chunks
+
+        const unsigned int chunks_in_z =
+          (array_planes + chunk_planes - 1) / chunk_planes; // 3 chunks, ragged
+        const unsigned int chunks_in_t =
+          (array_timepoints + chunk_timepoints - 1) /
+          chunk_timepoints; // 1 chunk
+
+        const ImageShape shape
+          {
+              .dims = {
+                .width = array_width,
+                .height = array_height,
+              },
+              .strides = {
+                .width = 1,
+                .height = array_width,
+                .planes = array_width * array_height,
+              },
+              .type = SampleType_u8,
+          };
+        const unsigned int nbytes_px = bytes_of_type(shape.type);
 
         try {
             auto thread_pool = std::make_shared<common::ThreadPool>(
               std::thread::hardware_concurrency(),
               [](const std::string& err) { LOGE("Error: %s", err.c_str()); });
 
-            ImageShape shape {
-                .dims = {
-                  .width = 64,
-                  .height = 48,
-                },
-                .strides = {
-                  .channels = 1,
-                  .width = 1,
-                  .height = 64,
-                  .planes = 64 * 48
-                },
-                .type = SampleType_u8,
-            };
-
             std::vector<zarr::Dimension> dims;
-            dims.emplace_back("x", DimensionType_Space, 64, 16, 0); // 4 chunks
-            dims.emplace_back("y", DimensionType_Space, 48, 16, 0); // 3 chunks
             dims.emplace_back(
-              "z", DimensionType_Space, 5, 2, 0); // 3 chunks, ragged
+              "x", DimensionType_Space, array_width, chunk_width, 0);
             dims.emplace_back(
-              "t", DimensionType_Time, 0, 5, 0); // 5 timepoints / chunk
+              "y", DimensionType_Space, array_height, chunk_height, 0);
+            dims.emplace_back(
+              "z", DimensionType_Space, array_planes, chunk_planes, 0);
+            dims.emplace_back(
+              "t", DimensionType_Time, array_timepoints, chunk_timepoints, 0);
 
             zarr::WriterConfig config = {
                 .image_shape = shape,
@@ -341,37 +390,31 @@ extern "C"
 
             zarr::ZarrV2Writer writer(config, thread_pool);
 
-            frame = (VideoFrame*)malloc(sizeof(VideoFrame) + 64 * 48);
-            frame->bytes_of_frame =
-              common::align_up(sizeof(VideoFrame) + 64 * 48, 8);
-            frame->shape = shape;
-            memset(frame->data, 0, 64 * 48);
+            const size_t frame_size = array_width * array_height * nbytes_px;
+            std::vector<uint8_t> data(frame_size, 0);
 
-            for (auto i = 0; i < 2 * 5; ++i) { // 5 time points
-                frame->frame_id = i;
-                CHECK(writer.write(frame));
+            for (auto i = 0; i < n_frames; ++i) {
+                CHECK(writer.write(data.data(), frame_size) == frame_size);
             }
             writer.finalize();
 
-            const auto expected_file_size = 16 * // x
-                                            16 * // y
-                                            2 *  // z
-                                            5;   // t
+            const auto expected_file_size =
+              chunk_width * chunk_height * chunk_planes * chunk_timepoints;
 
             CHECK(fs::is_directory(base_dir));
-            for (auto t = 0; t < 1; ++t) {
+            for (auto t = 0; t < chunks_in_t; ++t) {
                 const auto t_dir = base_dir / std::to_string(t);
                 CHECK(fs::is_directory(t_dir));
 
-                for (auto z = 0; z < 3; ++z) {
+                for (auto z = 0; z < chunks_in_z; ++z) {
                     const auto z_dir = t_dir / std::to_string(z);
                     CHECK(fs::is_directory(z_dir));
 
-                    for (auto y = 0; y < 3; ++y) {
+                    for (auto y = 0; y < chunks_in_y; ++y) {
                         const auto y_dir = z_dir / std::to_string(y);
                         CHECK(fs::is_directory(y_dir));
 
-                        for (auto x = 0; x < 4; ++x) {
+                        for (auto x = 0; x < chunks_in_x; ++x) {
                             const auto x_file =
                               base_dir / std::to_string(t) / std::to_string(z) /
                               std::to_string(y) / std::to_string(x);
@@ -380,15 +423,15 @@ extern "C"
                             CHECK(file_size == expected_file_size);
                         }
 
-                        CHECK(!fs::is_regular_file(y_dir / "4"));
+                        CHECK(!fs::is_regular_file(y_dir / std::to_string(chunks_in_x)));
                     }
 
-                    CHECK(!fs::is_directory(z_dir / "3"));
+                    CHECK(!fs::is_directory(z_dir / std::to_string(chunks_in_y)));
                 }
 
-                CHECK(!fs::is_directory(t_dir / "3"));
+                CHECK(!fs::is_directory(t_dir / std::to_string(chunks_in_z)));
             }
-            CHECK(!fs::is_directory(base_dir / "1"));
+            CHECK(!fs::is_directory(base_dir / std::to_string(chunks_in_t)));
 
             retval = 1;
         } catch (const std::exception& exc) {
@@ -400,9 +443,6 @@ extern "C"
         // cleanup
         if (fs::exists(base_dir)) {
             fs::remove_all(base_dir);
-        }
-        if (frame) {
-            free(frame);
         }
         return retval;
     }

--- a/src/writers/zarrv3.writer.cpp
+++ b/src/writers/zarrv3.writer.cpp
@@ -153,7 +153,59 @@ extern "C"
     {
         int retval = 0;
         const fs::path base_dir = fs::temp_directory_path() / "acquire";
-        struct VideoFrame* frame = nullptr;
+
+        const unsigned int array_width = 64, array_height = 48,
+                           array_planes = 6, array_channels = 8,
+                           array_timepoints = 10;
+        const unsigned int n_frames =
+          array_planes * array_channels * array_timepoints;
+
+        const unsigned int chunk_width = 16, chunk_height = 16,
+                           chunk_planes = 2, chunk_channels = 4,
+                           chunk_timepoints = 5;
+
+        const unsigned int shard_width = 2, shard_height = 1, shard_planes = 1,
+                           shard_channels = 2, shard_timepoints = 2;
+        const unsigned int chunks_per_shard = shard_width * shard_height *
+                                              shard_planes * shard_channels *
+                                              shard_timepoints;
+
+        const unsigned int chunks_in_x =
+          (array_width + chunk_width - 1) / chunk_width; // 4 chunks
+        const unsigned int chunks_in_y =
+          (array_height + chunk_height - 1) / chunk_height; // 3 chunks
+        const unsigned int chunks_in_z =
+          (array_planes + chunk_planes - 1) / chunk_planes; // 3 chunks
+        const unsigned int chunks_in_c =
+          (array_channels + chunk_channels - 1) / chunk_channels; // 2 chunks
+        const unsigned int chunks_in_t =
+          (array_timepoints + chunk_timepoints - 1) / chunk_timepoints;
+
+        const unsigned int shards_in_x =
+          (chunks_in_x + shard_width - 1) / shard_width; // 2 shards
+        const unsigned int shards_in_y =
+          (chunks_in_y + shard_height - 1) / shard_height; // 3 shards
+        const unsigned int shards_in_z =
+          (chunks_in_z + shard_planes - 1) / shard_planes; // 3 shards
+        const unsigned int shards_in_c =
+          (chunks_in_c + shard_channels - 1) / shard_channels; // 1 shard
+        const unsigned int shards_in_t =
+          (chunks_in_t + shard_timepoints - 1) / shard_timepoints; // 1 shard
+
+        const ImageShape shape
+          {
+              .dims = {
+                .width = array_width,
+                .height = array_height,
+              },
+              .strides = {
+                .width = 1,
+                .height = array_width,
+                .planes = array_width * array_height,
+              },
+              .type = SampleType_u16,
+          };
+        const unsigned int nbytes_px = bytes_of_type(shape.type);
 
         try {
             auto thread_pool = std::make_shared<common::ThreadPool>(
@@ -161,45 +213,28 @@ extern "C"
               [](const std::string& err) { LOGE("Error: %s", err.c_str()); });
 
             std::vector<zarr::Dimension> dims;
-            dims.emplace_back("x",
-                              DimensionType_Space,
-                              64,
-                              16, // 64 / 16 = 4 chunks
-                              2); // 4 / 2 = 2 shards
+            dims.emplace_back(
+              "x", DimensionType_Space, array_width, chunk_width, shard_width);
             dims.emplace_back("y",
                               DimensionType_Space,
-                              48,
-                              16, // 48 / 16 = 3 chunks
-                              1); // 3 / 1 = 3 shards
+                              array_height,
+                              chunk_height,
+                              shard_height);
             dims.emplace_back("z",
                               DimensionType_Space,
-                              6,
-                              2,  // 6 / 2 = 3 chunks
-                              1); // 3 / 1 = 3 shards
+                              array_planes,
+                              chunk_planes,
+                              shard_planes);
             dims.emplace_back("c",
                               DimensionType_Channel,
-                              8,
-                              4,  // 8 / 4 = 2 chunks
-                              2); // 4 / 2 = 2 shards
+                              array_channels,
+                              chunk_channels,
+                              shard_channels);
             dims.emplace_back("t",
                               DimensionType_Time,
-                              0,
-                              5,  // 5 timepoints / chunk
-                              2); // 2 chunks / shard
-
-            ImageShape shape {
-                .dims = {
-                  .width = 64,
-                  .height = 48,
-                },
-                .strides = {
-                  .channels = 1,
-                  .width = 1,
-                  .height = 64,
-                  .planes = 64 * 48
-                },
-                .type = SampleType_u16,
-            };
+                              array_timepoints,
+                              chunk_timepoints,
+                              shard_timepoints);
 
             zarr::WriterConfig config = {
                 .image_shape = shape,
@@ -210,74 +245,66 @@ extern "C"
 
             zarr::ZarrV3Writer writer(config, thread_pool);
 
-            const size_t frame_size = 64 * 48 * 2;
+            const size_t frame_size = array_width * array_height * nbytes_px;
+            std::vector<uint8_t> data(frame_size, 0);
 
-            frame = (VideoFrame*)malloc(sizeof(VideoFrame) + frame_size);
-            frame->bytes_of_frame =
-              common::align_up(sizeof(VideoFrame) + frame_size, 8);
-            frame->shape = shape;
-            memset(frame->data, 0, frame_size);
-
-            for (auto i = 0; i < 6 * 8 * 5 * 2; ++i) {
-                frame->frame_id = i;
-                CHECK(writer.write(frame));
+            for (auto i = 0; i < n_frames; ++i) {
+                CHECK(writer.write(data.data(), frame_size));
             }
             writer.finalize();
 
-            const auto chunk_size = 16 *               // x
-                                    16 *               // y
-                                    2 *                // z
-                                    4 *                // c
-                                    5 *                // t
-                                    2;                 // bytes per pixel
-            const auto index_size = 8 *                // 8 chunks
+            const auto chunk_size = chunk_width * chunk_height * chunk_planes *
+                                    chunk_channels * chunk_timepoints *
+                                    nbytes_px;
+            const auto index_size = chunks_per_shard *
                                     sizeof(uint64_t) * // indices are 64 bits
                                     2;                 // 2 indices per chunk
-            const auto expected_file_size = 2 *        // x
-                                              1 *      // y
-                                              1 *      // z
-                                              2 *      // c
-                                              2 *      // t
-                                              chunk_size +
+            const auto expected_file_size = shard_width * shard_height *
+                                              shard_planes * shard_channels *
+                                              shard_timepoints * chunk_size +
                                             index_size;
 
             CHECK(fs::is_directory(base_dir));
-            for (auto t = 0; t < 1; ++t) {
+            for (auto t = 0; t < shards_in_t; ++t) {
                 const auto t_dir = base_dir / ("c" + std::to_string(t));
                 CHECK(fs::is_directory(t_dir));
 
-                for (auto c = 0; c < 1; ++c) {
+                for (auto c = 0; c < shards_in_c; ++c) {
                     const auto c_dir = t_dir / std::to_string(c);
                     CHECK(fs::is_directory(c_dir));
 
-                    for (auto z = 0; z < 3; ++z) {
+                    for (auto z = 0; z < shards_in_z; ++z) {
                         const auto z_dir = c_dir / std::to_string(z);
                         CHECK(fs::is_directory(z_dir));
 
-                        for (auto y = 0; y < 3; ++y) {
+                        for (auto y = 0; y < shards_in_y; ++y) {
                             const auto y_dir = z_dir / std::to_string(y);
                             CHECK(fs::is_directory(y_dir));
 
-                            for (auto x = 0; x < 2; ++x) {
+                            for (auto x = 0; x < shards_in_x; ++x) {
                                 const auto x_file = y_dir / std::to_string(x);
                                 CHECK(fs::is_regular_file(x_file));
                                 const auto file_size = fs::file_size(x_file);
                                 CHECK(file_size == expected_file_size);
                             }
 
-                            CHECK(!fs::is_regular_file(y_dir / "2"));
+                            CHECK(!fs::is_regular_file(
+                              y_dir / std::to_string(shards_in_x)));
                         }
 
-                        CHECK(!fs::is_directory(z_dir / "3"));
+                        CHECK(!fs::is_directory(z_dir /
+                                                std::to_string(shards_in_y)));
                     }
 
-                    CHECK(!fs::is_directory(c_dir / "3"));
+                    CHECK(
+                      !fs::is_directory(c_dir / std::to_string(shards_in_z)));
                 }
 
-                CHECK(!fs::is_directory(t_dir / "1"));
+                CHECK(!fs::is_directory(t_dir / std::to_string(shards_in_c)));
             }
 
-            CHECK(!fs::is_directory(base_dir / "c1"));
+            CHECK(!fs::is_directory(base_dir /
+                                    ("c" + std::to_string(shards_in_t))));
 
             retval = 1;
         } catch (const std::exception& exc) {
@@ -289,9 +316,6 @@ extern "C"
         // cleanup
         if (fs::exists(base_dir)) {
             fs::remove_all(base_dir);
-        }
-        if (frame) {
-            free(frame);
         }
         return retval;
     }
@@ -300,7 +324,46 @@ extern "C"
     {
         int retval = 0;
         const fs::path base_dir = fs::temp_directory_path() / "acquire";
-        struct VideoFrame* frame = nullptr;
+
+        const unsigned int array_width = 64, array_height = 48,
+                           array_planes = 5;
+        const unsigned int n_frames = array_planes;
+
+        const unsigned int chunk_width = 16, chunk_height = 16,
+                           chunk_planes = 2;
+
+        const unsigned int shard_width = 2, shard_height = 1, shard_planes = 1;
+        const unsigned int chunks_per_shard =
+          shard_width * shard_height * shard_planes;
+
+        const unsigned int chunks_in_x =
+          (array_width + chunk_width - 1) / chunk_width; // 4 chunks
+        const unsigned int chunks_in_y =
+          (array_height + chunk_height - 1) / chunk_height; // 3 chunks
+        const unsigned int chunks_in_z =
+          (array_planes + chunk_planes - 1) / chunk_planes; // 3 chunks
+
+        const unsigned int shards_in_x =
+          (chunks_in_x + shard_width - 1) / shard_width; // 2 shards
+        const unsigned int shards_in_y =
+          (chunks_in_y + shard_height - 1) / shard_height; // 3 shards
+        const unsigned int shards_in_z =
+          (chunks_in_z + shard_planes - 1) / shard_planes; // 3 shards
+
+        const ImageShape shape
+          {
+              .dims = {
+                .width = array_width,
+                .height = array_height,
+              },
+              .strides = {
+                .width = 1,
+                .height = array_width,
+                .planes = array_width * array_height,
+              },
+              .type = SampleType_i8,
+          };
+        const unsigned int nbytes_px = bytes_of_type(shape.type);
 
         try {
             auto thread_pool = std::make_shared<common::ThreadPool>(
@@ -308,35 +371,18 @@ extern "C"
               [](const std::string& err) { LOGE("Error: %s", err.c_str()); });
 
             std::vector<zarr::Dimension> dims;
-            dims.emplace_back("x",
-                              DimensionType_Space,
-                              64,
-                              16, // 64 / 16 = 4 chunks
-                              2); // 4 / 2 = 2 shards
+            dims.emplace_back(
+              "x", DimensionType_Space, array_width, chunk_width, shard_width);
             dims.emplace_back("y",
                               DimensionType_Space,
-                              48,
-                              16, // 48 / 16 = 3 chunks
-                              1); // 3 / 1 = 3 shards
+                              array_height,
+                              chunk_height,
+                              shard_height);
             dims.emplace_back("z",
                               DimensionType_Space,
-                              5,
-                              2,  // 3 chunks, ragged
-                              1); // 3 / 1 = 3 shards
-
-            ImageShape shape {
-                .dims = {
-                  .width = 64,
-                  .height = 48,
-                },
-                .strides = {
-                  .channels = 1,
-                  .width = 1,
-                  .height = 64,
-                  .planes = 64 * 48
-                },
-                .type = SampleType_u8,
-            };
+                              array_planes,
+                              chunk_planes,
+                              shard_planes);
 
             zarr::WriterConfig config = {
                 .image_shape = shape,
@@ -347,53 +393,48 @@ extern "C"
 
             zarr::ZarrV3Writer writer(config, thread_pool);
 
-            frame = (VideoFrame*)malloc(sizeof(VideoFrame) + 64 * 48);
-            frame->bytes_of_frame =
-              common::align_up(sizeof(VideoFrame) + 64 * 48, 8);
-            frame->shape = shape;
-            memset(frame->data, 0, 64 * 48);
+            const size_t frame_size = array_width * array_height * nbytes_px;
+            std::vector<uint8_t> data(frame_size, 0);
 
-            for (auto i = 0; i < 5; ++i) {
-                frame->frame_id = i;
-                CHECK(writer.write(frame));
+            for (auto i = 0; i < n_frames; ++i) {
+                CHECK(writer.write(data.data(), frame_size) == frame_size);
             }
             writer.finalize();
 
-            const auto chunk_size = 16 *               // x
-                                    16 *               // y
-                                    2;                 // z
-            const auto index_size = 2 *                // 2 chunks
+            const auto chunk_size =
+              chunk_width * chunk_height * chunk_planes * nbytes_px;
+            const auto index_size = chunks_per_shard *
                                     sizeof(uint64_t) * // indices are 64 bits
                                     2;                 // 2 indices per chunk
-            const auto expected_file_size = 2 *        // x
-                                              1 *      // y
-                                              1 *      // z
-                                              chunk_size +
-                                            index_size;
+            const auto expected_file_size =
+              shard_width * shard_height * shard_planes * chunk_size +
+              index_size;
 
             CHECK(fs::is_directory(base_dir));
-            for (auto z = 0; z < 3; ++z) {
+            for (auto z = 0; z < shards_in_z; ++z) {
                 const auto z_dir = base_dir / ("c" + std::to_string(z));
                 CHECK(fs::is_directory(z_dir));
 
-                for (auto y = 0; y < 3; ++y) {
+                for (auto y = 0; y < shards_in_y; ++y) {
                     const auto y_dir = z_dir / std::to_string(y);
                     CHECK(fs::is_directory(y_dir));
 
-                    for (auto x = 0; x < 2; ++x) {
+                    for (auto x = 0; x < shards_in_x; ++x) {
                         const auto x_file = y_dir / std::to_string(x);
                         CHECK(fs::is_regular_file(x_file));
                         const auto file_size = fs::file_size(x_file);
                         CHECK(file_size == expected_file_size);
                     }
 
-                    CHECK(!fs::is_regular_file(y_dir / "2"));
+                    CHECK(!fs::is_regular_file(y_dir /
+                                               std::to_string(shards_in_x)));
                 }
 
-                CHECK(!fs::is_directory(z_dir / "3"));
+                CHECK(!fs::is_directory(z_dir / std::to_string(shards_in_y)));
             }
 
-            CHECK(!fs::is_directory(base_dir / "c3"));
+            CHECK(!fs::is_directory(base_dir /
+                                    ("c" + std::to_string(shards_in_z))));
 
             retval = 1;
         } catch (const std::exception& exc) {
@@ -406,58 +447,82 @@ extern "C"
         if (fs::exists(base_dir)) {
             fs::remove_all(base_dir);
         }
-        if (frame) {
-            free(frame);
-        }
         return retval;
     }
 
     acquire_export int unit_test__zarrv3_writer__write_ragged_internal_dim()
     {
-        const fs::path base_dir = fs::temp_directory_path() / "acquire";
-        struct VideoFrame* frame = nullptr;
         int retval = 0;
+        const fs::path base_dir = fs::temp_directory_path() / "acquire";
+
+        const unsigned int array_width = 64, array_height = 48,
+                           array_planes = 5, array_timepoints = 10;
+        const unsigned int n_frames = array_planes * array_timepoints;
+
+        const unsigned int chunk_width = 16, chunk_height = 16,
+                           chunk_planes = 2, chunk_timepoints = 5;
+
+        const unsigned int shard_width = 2, shard_height = 1, shard_planes = 1,
+                           shard_timepoints = 2;
+        const unsigned int chunks_per_shard =
+          shard_width * shard_height * shard_planes * shard_timepoints;
+
+        const unsigned int chunks_in_x =
+          (array_width + chunk_width - 1) / chunk_width; // 4 chunks
+        const unsigned int chunks_in_y =
+          (array_height + chunk_height - 1) / chunk_height; // 3 chunks
+        const unsigned int chunks_in_z =
+          (array_planes + chunk_planes - 1) / chunk_planes; // 3 chunks, ragged
+        const unsigned int chunks_in_t =
+          (array_timepoints + chunk_timepoints - 1) / chunk_timepoints;
+
+        const unsigned int shards_in_x =
+          (chunks_in_x + shard_width - 1) / shard_width; // 2 shards
+        const unsigned int shards_in_y =
+          (chunks_in_y + shard_height - 1) / shard_height; // 3 shards
+        const unsigned int shards_in_z =
+          (chunks_in_z + shard_planes - 1) / shard_planes; // 3 shards
+        const unsigned int shards_in_t =
+          (chunks_in_t + shard_timepoints - 1) / shard_timepoints; // 1 shard
+
+        const ImageShape shape
+          {
+              .dims = {
+                .width = array_width,
+                .height = array_height,
+              },
+              .strides = {
+                .width = 1,
+                .height = array_width,
+                .planes = array_width * array_height,
+              },
+              .type = SampleType_f32,
+          };
+        const unsigned int nbytes_px = bytes_of_type(shape.type);
 
         try {
             auto thread_pool = std::make_shared<common::ThreadPool>(
               std::thread::hardware_concurrency(),
               [](const std::string& err) { LOGE("Error: %s", err.c_str()); });
 
-            ImageShape shape {
-                .dims = {
-                  .width = 64,
-                  .height = 48,
-                },
-                .strides = {
-                  .channels = 1,
-                  .width = 1,
-                  .height = 64,
-                  .planes = 64 * 48
-                },
-                .type = SampleType_u8,
-            };
-
             std::vector<zarr::Dimension> dims;
-            dims.emplace_back("x",
-                              DimensionType_Space,
-                              64,
-                              16, // 64 / 16 = 4 chunks
-                              2); // 4 / 2 = 2 shards
+            dims.emplace_back(
+              "x", DimensionType_Space, array_width, chunk_width, shard_width);
             dims.emplace_back("y",
                               DimensionType_Space,
-                              48,
-                              16, // 48 / 16 = 3 chunks
-                              1); // 3 / 1 = 3 shards
+                              array_height,
+                              chunk_height,
+                              shard_height);
             dims.emplace_back("z",
                               DimensionType_Space,
-                              5,
-                              2,  // 3 chunks, ragged
-                              1); // 3 / 1 = 3 shards
+                              array_planes,
+                              chunk_planes,
+                              shard_planes);
             dims.emplace_back("t",
                               DimensionType_Time,
-                              0,
-                              5,  // 5 timepoints / chunk
-                              2); // 2 chunks / shard
+                              array_timepoints,
+                              chunk_timepoints,
+                              shard_timepoints);
 
             zarr::WriterConfig config = {
                 .image_shape = shape,
@@ -468,62 +533,57 @@ extern "C"
 
             zarr::ZarrV3Writer writer(config, thread_pool);
 
-            frame = (VideoFrame*)malloc(sizeof(VideoFrame) + 64 * 48);
-            frame->bytes_of_frame =
-              common::align_up(sizeof(VideoFrame) + 64 * 48, 8);
-            frame->shape = shape;
-            memset(frame->data, 0, 64 * 48);
+            const size_t frame_size = array_width * array_height * nbytes_px;
+            std::vector<uint8_t> data(frame_size, 0);
 
-            for (auto i = 0; i < 5 * 10; ++i) { // 10 time points (2 chunks)
-                frame->frame_id = i;
-                CHECK(writer.write(frame));
+            for (auto i = 0; i < n_frames; ++i) {
+                CHECK(writer.write(data.data(), frame_size) == frame_size);
             }
             writer.finalize();
 
-            const auto chunk_size = 16 *               // x
-                                    16 *               // y
-                                    2 *                // z
-                                    5;                 // t
-            const auto index_size = 4 *                // 4 chunks
+            const auto chunk_size = chunk_width * chunk_height * chunk_planes *
+                                    chunk_timepoints * nbytes_px;
+            const auto index_size = chunks_per_shard *
                                     sizeof(uint64_t) * // indices are 64 bits
                                     2;                 // 2 indices per chunk
-            const auto expected_file_size = 2 *        // x
-                                              1 *      // y
-                                              1 *      // z
-                                              2 *      // t
+            const auto expected_file_size = shard_width * shard_height *
+                                              shard_planes * shard_timepoints *
                                               chunk_size +
                                             index_size;
 
             CHECK(fs::is_directory(base_dir));
-            for (auto t = 0; t < 1; ++t) {
+            for (auto t = 0; t < shards_in_t; ++t) {
                 const auto t_dir = base_dir / ("c" + std::to_string(t));
                 CHECK(fs::is_directory(t_dir));
 
-                for (auto z = 0; z < 3; ++z) {
+                for (auto z = 0; z < shards_in_z; ++z) {
                     const auto z_dir = t_dir / std::to_string(z);
                     CHECK(fs::is_directory(z_dir));
 
-                    for (auto y = 0; y < 3; ++y) {
+                    for (auto y = 0; y < shards_in_y; ++y) {
                         const auto y_dir = z_dir / std::to_string(y);
                         CHECK(fs::is_directory(y_dir));
 
-                        for (auto x = 0; x < 2; ++x) {
+                        for (auto x = 0; x < shards_in_x; ++x) {
                             const auto x_file = y_dir / std::to_string(x);
                             CHECK(fs::is_regular_file(x_file));
                             const auto file_size = fs::file_size(x_file);
                             CHECK(file_size == expected_file_size);
                         }
 
-                        CHECK(!fs::is_regular_file(y_dir / "2"));
+                        CHECK(!fs::is_regular_file(
+                          y_dir / std::to_string(shards_in_x)));
                     }
 
-                    CHECK(!fs::is_directory(z_dir / "3"));
+                    CHECK(
+                      !fs::is_directory(z_dir / std::to_string(shards_in_y)));
                 }
 
-                CHECK(!fs::is_directory(t_dir / "3"));
+                CHECK(!fs::is_directory(t_dir / std::to_string(shards_in_z)));
             }
 
-            CHECK(!fs::is_directory(base_dir / "c1"));
+            CHECK(!fs::is_directory(base_dir /
+                                    ("c" + std::to_string(shards_in_t))));
 
             retval = 1;
         } catch (const std::exception& exc) {
@@ -535,9 +595,6 @@ extern "C"
         // cleanup
         if (fs::exists(base_dir)) {
             fs::remove_all(base_dir);
-        }
-        if (frame) {
-            free(frame);
         }
         return retval;
     }

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -33,6 +33,9 @@ struct Zarr : public Storage
     void start();
     int stop() noexcept;
     size_t append(const VideoFrame* frames, size_t nbytes);
+    size_t append_frame(uint8_t *constdata,
+                        size_t bytes_of_data,
+                        const ImageShape& shape);
     void reserve_image_shape(const ImageShape* shape);
 
     /// Error state
@@ -86,7 +89,9 @@ struct Zarr : public Storage
     virtual void write_array_metadata_(size_t level) const = 0;
 
     /// Multiscale
-    void write_multiscale_frames_(const VideoFrame* frame);
+    void write_multiscale_frames_(uint8_t *const data_,
+                                  size_t bytes_of_data,
+                                  const ImageShape& shape_);
 };
 
 } // namespace acquire::sink::zarr

--- a/src/zarr.hh
+++ b/src/zarr.hh
@@ -33,7 +33,7 @@ struct Zarr : public Storage
     void start();
     int stop() noexcept;
     size_t append(const VideoFrame* frames, size_t nbytes);
-    size_t append_frame(uint8_t *constdata,
+    size_t append_frame(const uint8_t* data,
                         size_t bytes_of_data,
                         const ImageShape& shape);
     void reserve_image_shape(const ImageShape* shape);
@@ -89,7 +89,7 @@ struct Zarr : public Storage
     virtual void write_array_metadata_(size_t level) const = 0;
 
     /// Multiscale
-    void write_multiscale_frames_(uint8_t *const data_,
+    void write_multiscale_frames_(const uint8_t* data_,
                                   size_t bytes_of_data,
                                   const ImageShape& shape_);
 };

--- a/tests/unit-tests.cpp
+++ b/tests/unit-tests.cpp
@@ -83,6 +83,8 @@ main()
     const std::vector<testcase> tests{
 #define CASE(e) { .name = #e, .test = (int (*)())lib_load(&lib, #e) }
         CASE(unit_test__trim),
+        CASE(unit_test__shard_index_for_chunk),
+        CASE(unit_test__shard_internal_index),
         CASE(unit_test__average_frame),
         CASE(unit_test__thread_pool__push_to_job_queue),
         CASE(unit_test__sink_creator__create_chunk_file_sinks),
@@ -90,13 +92,11 @@ main()
         CASE(unit_test__chunk_lattice_index),
         CASE(unit_test__tile_group_offset),
         CASE(unit_test__chunk_internal_offset),
-        CASE(unit_test__writer__write_frame_to_chunks),
         CASE(unit_test__downsample_writer_config),
+        CASE(unit_test__writer__write_frame_to_chunks),
         CASE(unit_test__zarrv2_writer__write_even),
         CASE(unit_test__zarrv2_writer__write_ragged_append_dim),
-        CASE(unit_test__shard_index_for_chunk),
         CASE(unit_test__zarrv2_writer__write_ragged_internal_dim),
-        CASE(unit_test__shard_internal_index),
         CASE(unit_test__zarrv3_writer__write_even),
         CASE(unit_test__zarrv3_writer__write_ragged_append_dim),
         CASE(unit_test__zarrv3_writer__write_ragged_internal_dim),


### PR DESCRIPTION
I updated `Zarr::append()` to call the new `Zarr::append_frame()`. Multiscale logic goes from `append()` into `append_frame()`, so I needed to retool `Zarr::write_multiscale_frames_()` to accept `uint8_t*` and `size_t` instead of `VideoFrame`.

I also updated `Writer::write()` to both take `uint8_t*` and `size_t` instead of `VideoFrame`, and also return a `size_t` of the number of bytes written in anticipation of establishing a contract around writing (separate PR). Because of this change, I had to update the unit tests around `{Writer,ZarrV2Writer,ZarrV3Writer}::write()`, and I took the opportunity to define constant values instead of hardcoding numbers. The tests are otherwise the same.

Also the unit tests are slightly reordered for aesthetic reasons.